### PR TITLE
Localhost Testnet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 # Test binary, built with `go test -c`
 *.test
 
+/.nodes
+
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 

--- a/README.md
+++ b/README.md
@@ -7,80 +7,80 @@ Accumulate anticipates a world where the blockchain is a network of blockchain s
 ## Introduction
 A typical blockchain is organized around addresses, as pioneered by Bitcoin,
 the first blockchain.  Addresses are usually controlled by a public/private
-key pair. In this case, addresses (or accounts) are a hash or partial hash 
-of the public key.  This hides the public key until some spend occurs, 
-identifying the address as based on a particular public/private key pair.  
-Other options exist, like smart contracts with ethereum.  In this case the 
-account is the basis for calling functions against the smart contract and 
+key pair. In this case, addresses (or accounts) are a hash or partial hash
+of the public key.  This hides the public key until some spend occurs,
+identifying the address as based on a particular public/private key pair.
+Other options exist, like smart contracts with ethereum.  In this case the
+account is the basis for calling functions against the smart contract and
 potentially updating its state.
 
-Blockchains use smart contracts to expand blockchains beyond simple 
-exchanges of tokens, making the exchange of tokens dependent on more complex 
-calculations using data and inputs from multiple users.  Naturally, the data 
-on the blockchain is pretty limited when it comes to interacting with the 
-real world, creating a need for trusted oracles to provide real world data 
+Blockchains use smart contracts to expand blockchains beyond simple
+exchanges of tokens, making the exchange of tokens dependent on more complex
+calculations using data and inputs from multiple users.  Naturally, the data
+on the blockchain is pretty limited when it comes to interacting with the
+real world, creating a need for trusted oracles to provide real world data
 to the blockchain.
 
-Many blockchains seek to scale transactions and smart contracts through 
-various approaches to sharding and parallel processing.  Networks of 
-independent blockchains can do so, since independent chains don’t interact 
-at the verification layer.  Dependencies in processes important to users are 
-handled by external mechanisms.  The risks of trusting such external 
-mechanisms is restricted to those blockchain users that choose to depend on 
+Many blockchains seek to scale transactions and smart contracts through
+various approaches to sharding and parallel processing.  Networks of
+independent blockchains can do so, since independent chains don’t interact
+at the verification layer.  Dependencies in processes important to users are
+handled by external mechanisms.  The risks of trusting such external
+mechanisms is restricted to those blockchain users that choose to depend on
 externalities.
 
-In the case of tokens of one blockchain being traded on another chain or 
-sidechain, the security of using tokens with characteristics defined off 
-chain depends on the processes used to communicate between chains. Smart 
-contracts can embed some of these processes on chain, but cannot fully 
-secure the communication between independent chains, since validation of 
-what happens on one chain cannot serve as inputs for a smart contract on 
+In the case of tokens of one blockchain being traded on another chain or
+sidechain, the security of using tokens with characteristics defined off
+chain depends on the processes used to communicate between chains. Smart
+contracts can embed some of these processes on chain, but cannot fully
+secure the communication between independent chains, since validation of
+what happens on one chain cannot serve as inputs for a smart contract on
 another chain.
 
-One mechanism used by many smart contract based protocols is to define bonds 
-to penalize malfeasance in the communication between independent chains. 
-Bonds are being used today for validators.  Still, creating cryptographic 
-proofs of malfeasance to apply penalties is challenging. The parties that 
-validate information across the chains can be viewed as validators. Parties 
+One mechanism used by many smart contract based protocols is to define bonds
+to penalize malfeasance in the communication between independent chains.
+Bonds are being used today for validators.  Still, creating cryptographic
+proofs of malfeasance to apply penalties is challenging. The parties that
+validate information across the chains can be viewed as validators. Parties
 that validate their performance can be viewed as auditors.
 
-Accumulate takes a pragmatic approach to defining the risk and independence 
-of transactions across the protocol by using short block sizes and adding 
-latency between the validation and recording of transactions, and the 
-application of the outcome of a transaction to the state of the blockchain.  
-Accumulate processes transactions as submitted by users of the protocol 
-directly, but rather than these changing the state of the blockchain, user 
-transactions create synthetic transactions that are then processed by the 
-protocol.  Because user transactions are limited to changing only one part 
-of the protocol, they can almost always be processed in parallel.  Since 
+Accumulate takes a pragmatic approach to defining the risk and independence
+of transactions across the protocol by using short block sizes and adding
+latency between the validation and recording of transactions, and the
+application of the outcome of a transaction to the state of the blockchain.
+Accumulate processes transactions as submitted by users of the protocol
+directly, but rather than these changing the state of the blockchain, user
+transactions create synthetic transactions that are then processed by the
+protocol.  Because user transactions are limited to changing only one part
+of the protocol, they can almost always be processed in parallel.  Since
 synthetic transactions are limited to changing only one part of the protocol,
 they too can be processed in parallel in following blocks.
 
-Accumulate is built around Accumulate Digital Identities (ADIs).  ADIs are 
-identifiers specified by the users and applications that build them.  The 
-keys that manage ADIs are separate, and can be managed over time. The keys 
-to an ADI can be managed (like signers on an account) so that new ADIs don’t 
-have to be issued just because a company must shift responsibilities over 
-time.  The departure of an employee should not require new ADIs, just new 
+Accumulate is built around Accumulate Digital Identities (ADIs).  ADIs are
+identifiers specified by the users and applications that build them.  The
+keys that manage ADIs are separate, and can be managed over time. The keys
+to an ADI can be managed (like signers on an account) so that new ADIs don’t
+have to be issued just because a company must shift responsibilities over
+time.  The departure of an employee should not require new ADIs, just new
 security.
 
 Even the technology of keys and signing should allow upgrades in Accumulate without major upending of the actual ADIs.
 
 Accumulate also anticipates the need for ADIs to manage identities, processes, tokens, and data.  Everything in Accumulate can be addressed through UDIs. Applying Internet standards for addressing and routing to the blockchain allows blockchains to scale just as the Internet has proven to be able to scale.
 
-One of the issues with much security in blockchains is the off blockchain processes that are needed to arrive at an entry on the blockchain.  Developers are faced with a trade off between the expense and difficulty of showing their work on the blockchain, and the lack of accountability when the work of coming to consensus is done off blockchain.  
+One of the issues with much security in blockchains is the off blockchain processes that are needed to arrive at an entry on the blockchain.  Developers are faced with a trade off between the expense and difficulty of showing their work on the blockchain, and the lack of accountability when the work of coming to consensus is done off blockchain.
 
 Accumulate provides scratch space on the blockchain that can be used by parties to come to consensus, but whose data availability is not enforced by Accumulate forever.  Scratch space allows processes to provide cryptographic proof of validation and process without over burdening the blockchain.
 
 # Factom/Accumulate Innovations
-A quick summary of the innovations and advantages of Factom and Accumulate that 
-greatly aid integrations of real world applications and use cases with the 
+A quick summary of the innovations and advantages of Factom and Accumulate that
+greatly aid integrations of real world applications and use cases with the
 blockchain technology:
 
 * Factom's data based blockchain innovations:
   * User Chains -- Data organized in chains
   * Performance -- Scalable architecture
-  * Two Token Architecture -- Separate, non-transferable credit tokens for fee 
+  * Two Token Architecture -- Separate, non-transferable credit tokens for fee
   payment
   * Anchoring -- Taps into cryptographic security of other blockchains
   * Cryptographic proofs of all blockchain contents against all anchors
@@ -89,35 +89,61 @@ blockchain technology:
   * Token issuance -- any identity can issue tokens
   * Token management -- tokens are held by identities, and sent to identities
   * Data management -- data chains are created and controlled by Identities
-  * Scratch Space 
+  * Scratch Space
      * Coordination -- multi-party transaction construction on the blockchain
-     * Limited availability -- Not guaranteed after 20,000 blocks (about 2.3 
+     * Limited availability -- Not guaranteed after 20,000 blocks (about 2.3
        weeks)
      * Segregated witness -- Bulky authorizations don’t bloat the blockchain
-     * Blockchain rewriting -- Blends advantages of 10 second blocks with 10 
+     * Blockchain rewriting -- Blends advantages of 10 second blocks with 10
        minute blocks
   * Performance
-     * Sharding -- Block Validator Chains (BVCs) and the Directory Block Chain 
+     * Sharding -- Block Validator Chains (BVCs) and the Directory Block Chain
     (DBC) run independently
-     * Synthetic Transactions -- Transaction processing runs in parallel with 
+     * Synthetic Transactions -- Transaction processing runs in parallel with
        blockchain syncronization
      * BVCs and DBC each run their own consensus (independently)
      * Tokens are tracked across accounts, one chain per account
      * All accounts can process transactions in parallel
      * All Identity validation can be processed in parallel
-     * Tendermint Consensus will be run for each BVC and the DBC so that 
+     * Tendermint Consensus will be run for each BVC and the DBC so that
         adding BVCs adds capacity very close to linearly
      * Tendermint capacity is about 1000 to 10,000 tps per BVC
-     * State required to validate a chain is preserved on-chain; syncing with a 
-       chain for building or accessing the current state of the blockchain 
+     * State required to validate a chain is preserved on-chain; syncing with a
+       chain for building or accessing the current state of the blockchain
        is nearly instant.
-     * Maintaining the data and history of the blockchain is 
-       maintained on validator nodes separate from data nodes for accessing 
+     * Maintaining the data and history of the blockchain is
+       maintained on validator nodes separate from data nodes for accessing
        the past state of the blockchain
   * URLs
      * URL addressing of Accumulate identities, data, transactions, and state
 Traditional technology stacks easily integrate with URL addressable data and endpoints
 Much improved user experience
 Enables integration with browsers
-     * Tokens can be sent to human readable URLs rather than odd collections 
+     * Tokens can be sent to human readable URLs rather than odd collections
        of characters
+
+## CLI
+
+### Main TestNet
+
+To initialize node configuration in `~/.accumulate`, choose a network from
+`networks/networks.go`, and run `accumulated init -n <name>`.
+
+Once `~/.accumulate` is initialized, run `accumulated run -n <n>` where `<n>` is
+the index of the node you want to run. For example, "Arches" has two nodes,
+index 0 and index 1.
+
+### Local TestNet
+
+To set up a testnet on your PC, using localhost addresses, run `accumulated
+testnet -w <config-dir>`, e.g. `accumulated testnet -w ./nodes`.
+
+- `-v/--validators` sets the number of nodes created, default 3.
+- `--ip` sets the IP address of the first node, default `127.0.1.1`. Nodes after
+  the first will increment the IP, e.g. `127.0.1.2`.
+- `--port` sets the base port, default `26656`. Tendermint P2P will run on the
+  base port, Tendermint RPC on base port + 1, Tendermint GRPC on +2, Accumulate
+  RPC on +3, Accumulate JSONRPC API on +4, and Accumulate REST API on +5.
+
+To run a node in the testnet, run `accumulated run -w <dir>/Node<n>`, e.g.
+`accumulated run -w ./nodes/Node0`.

--- a/blockchain/accumulate/accnode.go
+++ b/blockchain/accumulate/accnode.go
@@ -5,18 +5,22 @@ import (
 
 	"github.com/AccumulateNetwork/accumulated/blockchain/tendermint"
 	"github.com/AccumulateNetwork/accumulated/blockchain/validator"
+	"github.com/AccumulateNetwork/accumulated/config"
 )
 
-func CreateAccumulateBVC(config string, path string) (*tendermint.AccumulatorVMApplication, error) {
+func CreateAccumulateBVC(config *config.Config) (*tendermint.AccumulatorVMApplication, error) {
 	//create a tendermint AccumulatorVM
-	acc := tendermint.NewAccumulatorVMApplication(config, path)
+	acc := tendermint.NewAccumulatorVMApplication(config)
 
 	//extract the signing key from the tendermint node
 	key := ed25519.PrivateKey{}
 	key = acc.Key.PrivKey.Bytes()
 
 	//create the bvc and give it the signing key
-	bvc := NewBVCNode(config, path, key)
+	bvc, err := NewBVCNode(config, key)
+	if err != nil {
+		return nil, err
+	}
 
 	//give the tendermint application the validator node to use
 	acc.SetAccumulateNode(bvc)
@@ -29,16 +33,19 @@ func CreateAccumulateBVC(config string, path string) (*tendermint.AccumulatorVMA
 	return acc, nil
 }
 
-func CreateAccumulateDC(config string, path string) *tendermint.AccumulatorVMApplication {
+func CreateAccumulateDC(config *config.Config) (*tendermint.AccumulatorVMApplication, error) {
 	//create a tendermint AccumulatorVM
-	acc := tendermint.NewAccumulatorVMApplication(config, path)
+	acc := tendermint.NewAccumulatorVMApplication(config)
 
 	//extract the signing key from the tendermint node
 	key := ed25519.PrivateKey{}
 	key = acc.Key.PrivKey.Bytes()
 
 	//create the bvc and give it the signing key
-	dc := NewDCNode(config, path, key)
+	dc, err := NewDCNode(config, key)
+	if err != nil {
+		return nil, err
+	}
 
 	//give the tendermint application the validator node to use
 	acc.SetAccumulateNode(dc)
@@ -47,27 +54,30 @@ func CreateAccumulateDC(config string, path string) *tendermint.AccumulatorVMApp
 	go acc.Start()
 
 	acc.Wait()
-	return acc
+	return acc, nil
 }
 
 type BVCNode struct {
 	validator.Node
 }
 
-func NewBVCNode(configFile string, path string, key ed25519.PrivateKey) *validator.Node {
+func NewBVCNode(config *config.Config, key ed25519.PrivateKey) (*validator.Node, error) {
 	bvc := &validator.Node{}
-	bvc.Initialize(configFile, path, key, &validator.NewBlockValidatorChain().ValidatorContext)
-	return bvc
+	err := bvc.Initialize(config, key, &validator.NewBlockValidatorChain().ValidatorContext)
+	if err != nil {
+		return nil, err
+	}
+	return bvc, nil
 }
 
-func NewDCNode(configFile string, path string, key ed25519.PrivateKey) *validator.Node {
+func NewDCNode(config *config.Config, key ed25519.PrivateKey) (*validator.Node, error) {
 	bvc := &validator.Node{}
-	//bvc.Initialize(configFile, path, key, &validator.NewDirectoryChain().ValidatorContext)
-	return bvc
+	//bvc.Initialize(config, key, &validator.NewDirectoryChain().ValidatorContext)
+	return bvc, nil
 }
 
-func NewDSNode(configFile string, path string, key ed25519.PrivateKey) *validator.Node {
+func NewDSNode(config *config.Config, key ed25519.PrivateKey) (*validator.Node, error) {
 	bvc := &validator.Node{}
-	//bvc.Initialize(configFile, path, key, &validator.NewDataStore().ValidatorContext)
-	return bvc
+	//bvc.Initialize(config, key, &validator.NewDataStore().ValidatorContext)
+	return bvc, nil
 }

--- a/blockchain/tendermint/abci-dbvc.go
+++ b/blockchain/tendermint/abci-dbvc.go
@@ -1,18 +1,17 @@
 package tendermint
 
 import (
-	vadb "github.com/AccumulateNetwork/ValidatorAccumulator/ValAcc/database"
-	"github.com/tendermint/tendermint/abci/example/code"
-	dbm "github.com/tendermint/tm-db"
-
-	//"github.com/Workiva/go-datastructures/threadsafe/err"
-
-	//"encoding/binary"
 	"fmt"
 	"os"
 
+	vadb "github.com/AccumulateNetwork/ValidatorAccumulator/ValAcc/database"
+	"github.com/AccumulateNetwork/ValidatorAccumulator/ValAcc/merkleDag"
+	valacctypes "github.com/AccumulateNetwork/ValidatorAccumulator/ValAcc/types"
+	pb "github.com/AccumulateNetwork/accumulated/types/proto"
 	"github.com/golang/protobuf/proto"
 	"github.com/spf13/viper"
+	"github.com/tendermint/tendermint/abci/example/code"
+	abci "github.com/tendermint/tendermint/abci/types"
 	cfg "github.com/tendermint/tendermint/config"
 	tmflags "github.com/tendermint/tendermint/libs/cli/flags"
 	"github.com/tendermint/tendermint/libs/log"
@@ -20,15 +19,8 @@ import (
 	"github.com/tendermint/tendermint/p2p"
 	"github.com/tendermint/tendermint/privval"
 	"github.com/tendermint/tendermint/proxy"
-
-	//"github.com/AccumulateNetwork/ValidatorAccumulator/ValAcc/node"
-	//router2 "github.com/AccumulateNetwork/ValidatorAccumulator/ValAcc/router"
-	pb "github.com/AccumulateNetwork/accumulated/types/proto"
-	abci "github.com/tendermint/tendermint/abci/types"
-	ed25519 "golang.org/x/crypto/ed25519"
-
-	"github.com/AccumulateNetwork/ValidatorAccumulator/ValAcc/merkleDag"
-	valacctypes "github.com/AccumulateNetwork/ValidatorAccumulator/ValAcc/types"
+	dbm "github.com/tendermint/tm-db"
+	"golang.org/x/crypto/ed25519"
 )
 
 var (
@@ -50,6 +42,8 @@ type DirectoryBlockChain struct {
 	//	BootstrapHeight int64
 	Height uint64
 
+	config *cfg.Config
+
 	md        merkleDag.MD
 	AppMDRoot valacctypes.Hash
 
@@ -64,10 +58,6 @@ func (app *DirectoryBlockChain) GetHeight() uint64 {
 
 func (DirectoryBlockChain) Info(abci.RequestInfo) abci.ResponseInfo {
 	return abci.ResponseInfo{}
-}
-
-func (DirectoryBlockChain) SetOption(abci.RequestSetOption) abci.ResponseSetOption {
-	return abci.ResponseSetOption{}
 }
 
 func (app *DirectoryBlockChain) resolveDDIIatHeight(ddii []byte, bvcheight int64) (ed25519.PublicKey, error) {

--- a/blockchain/tendermint/tendermint.go
+++ b/blockchain/tendermint/tendermint.go
@@ -74,7 +74,7 @@ func InitWithConfig(workDir, shardName, chainID string, port int, config []*cfg.
 		config.RPC.GRPCListenAddress = fmt.Sprintf("%s:%d", listenIP[i], port+2)
 		config.Instrumentation.PrometheusListenAddr = fmt.Sprintf(":%d", port)
 
-		config.Consensus.CreateEmptyBlocks = false
+		// config.Consensus.CreateEmptyBlocks = false
 		err = os.MkdirAll(path.Join(nodeDir, "config"), nodeDirPerm)
 		if err != nil {
 			return fmt.Errorf("failed to create config dir: %v", err)
@@ -150,9 +150,9 @@ func InitWithConfig(workDir, shardName, chainID string, port int, config []*cfg.
 		}
 		config.Moniker = fmt.Sprintf("Node%d", i)
 
-		config.Accumulate.RPC.ListenAddress = fmt.Sprintf("%s:%d", listenIP[i], port+3)
-		config.Accumulate.Router.JSONListenAddress = fmt.Sprintf("%s:%d", listenIP[i], port+4)
-		config.Accumulate.Router.RESTListenAddress = fmt.Sprintf("%s:%d", listenIP[i], port+5)
+		config.Accumulate.AccRPC.ListenAddress = fmt.Sprintf("%s:%d", listenIP[i], port+3)
+		config.Accumulate.AccRouter.JSONListenAddress = fmt.Sprintf("%s:%d", listenIP[i], port+4)
+		config.Accumulate.AccRouter.RESTListenAddress = fmt.Sprintf("%s:%d", listenIP[i], port+5)
 
 		err := cfg.Store(config)
 		if err != nil {

--- a/blockchain/validator/Node.go
+++ b/blockchain/validator/Node.go
@@ -5,10 +5,12 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
-	"github.com/AccumulateNetwork/SMT/common"
+	"path/filepath"
 	"sync"
 	"time"
 
+	"github.com/AccumulateNetwork/SMT/common"
+	"github.com/AccumulateNetwork/accumulated/config"
 	"github.com/AccumulateNetwork/accumulated/networks"
 	"github.com/AccumulateNetwork/accumulated/types"
 	"github.com/AccumulateNetwork/accumulated/types/api"
@@ -21,8 +23,6 @@ import (
 
 // Node implements the general parameters to stimulate the validators, provide synthetic transactions, and issue state changes
 type Node struct {
-	AccRpcAddr string
-
 	mmDB           state.StateDB     // State database
 	chainValidator *ValidatorContext // Chain Validator
 	leader         bool
@@ -38,31 +38,20 @@ type Node struct {
 }
 
 // Initialize will setup the node with the given parameters.  What we really need here are the bouncer, and private key
-func (app *Node) Initialize(configFile string, workingDir string, key ed25519.PrivateKey, chainValidator *ValidatorContext) error {
-	v := viper.New()
-	v.SetConfigFile(configFile)
-	v.AddConfigPath(workingDir)
-	if err := v.ReadInConfig(); err != nil {
-
-		return fmt.Errorf("viper failed to read config file: %w", err)
-	}
-
-	//create a connection to the router.
-	app.AccRpcAddr = v.GetString("accumulate.AccRPCAddress")
-
-	networkId := viper.GetString("instrumentation/namespace")
+func (app *Node) Initialize(config *config.Config, key ed25519.PrivateKey, chainValidator *ValidatorContext) error {
+	networkId := config.Instrumentation.Namespace
 	bvcId := sha256.Sum256([]byte(networkId))
-	dbFilename := workingDir + "/" + "valacc.db"
+	dbFilename := filepath.Join(config.RootDir, "valacc.db")
 	err := app.mmDB.Open(dbFilename, bvcId[:], false, true)
 	if err != nil {
-		return fmt.Errorf("failed to open database %s, %v", dbFilename, err)
+		return fmt.Errorf("opening database %s: %v", dbFilename, err)
 	}
 
 	laddr := viper.GetString("rpc.laddr")
 
 	rpcClient, err := rpchttp.New(laddr, "/websocket")
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("creating RPC client: %v", err)
 	}
 
 	app.chainValidator = chainValidator

--- a/cmd/accumulated/cmd_testnet.go
+++ b/cmd/accumulated/cmd_testnet.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+
+	"github.com/AccumulateNetwork/accumulated/blockchain/tendermint"
+	cfg "github.com/AccumulateNetwork/accumulated/config"
+	"github.com/spf13/cobra"
+)
+
+var cmdTestNet = &cobra.Command{
+	Use:   "testnet",
+	Short: "Create a LAN testnet using 127.0.1.X",
+	Run:   initTestNet,
+}
+
+var flagTestNet struct {
+	NumValidators int
+	BasePort      int
+	BaseIP        string
+}
+
+func init() {
+	cmdMain.AddCommand(cmdTestNet)
+
+	cmdTestNet.Flags().IntVarP(&flagTestNet.NumValidators, "validators", "v", 3, "Number of validator nodes to configure")
+	cmdTestNet.Flags().IntVar(&flagTestNet.BasePort, "port", 26656, "Base port to use for listeners")
+	cmdTestNet.Flags().StringVar(&flagTestNet.BaseIP, "ip", "127.0.1.1", "Base IP address for nodes - must not end with .0")
+}
+
+func initTestNet(cmd *cobra.Command, args []string) {
+	baseIP := net.ParseIP(flagTestNet.BaseIP)
+	if baseIP == nil {
+		fmt.Fprintf(os.Stderr, "Error: %q is not a valid IP address\n", flagTestNet.BaseIP)
+		cmd.Usage()
+		os.Exit(1)
+	}
+	if baseIP[15] == 0 {
+		fmt.Fprintf(os.Stderr, "Error: base IP address must not end with .0\n")
+		cmd.Usage()
+		os.Exit(1)
+	}
+
+	if !cmd.Flag("work-dir").Changed {
+		fmt.Fprint(os.Stderr, "Error: --work-dir is required\n")
+		_ = cmd.Usage()
+		os.Exit(1)
+	}
+
+	IPs := make([]string, flagTestNet.NumValidators)
+	for i := range IPs {
+		ip := baseIP
+		ip[15] += byte(i)
+		IPs[i] = fmt.Sprintf("tcp://%v", ip)
+	}
+
+	config := make([]*cfg.Config, flagTestNet.NumValidators)
+	for i := range config {
+		config[i] = cfg.Default()
+	}
+
+	err := tendermint.InitWithConfig(flagMain.WorkDir, "LocalhostTestNet", "LocalhostTestNet", flagTestNet.BasePort, config, IPs, IPs)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -11,14 +11,20 @@ import (
 	tm "github.com/tendermint/tendermint/config"
 )
 
+func Default() *Config {
+	c := new(Config)
+	c.Config = *tm.DefaultConfig()
+	return c
+}
+
 type Config struct {
 	tm.Config  `mapstructure:",squash"`
 	Accumulate Accumulate `mapstructure:",squash"`
 }
 
 type Accumulate struct {
-	RPC    RPC    `toml:"acc-rpc" mapstructure:"acc-rpc"`
-	Router Router `toml:"acc-router" mapstructure:"acc-router"`
+	AccRPC    RPC    `toml:"acc-rpc" mapstructure:"acc-rpc"`
+	AccRouter Router `toml:"acc-router" mapstructure:"acc-router"`
 }
 
 type RPC struct {
@@ -57,10 +63,12 @@ func LoadFile(dir, file string) (*Config, error) {
 }
 
 func Store(config *Config) error {
-	// panics on fail
-	tm.WriteConfigFile(config.RootDir, &config.Config)
+	file := filepath.Join(config.RootDir, "config", "config.toml")
 
-	f, err := os.OpenFile(filepath.Join(config.RootDir, "config", "config.toml"), os.O_WRONLY, 0600)
+	// exits on fail
+	tm.WriteConfigFile(file, &config.Config)
+
+	f, err := os.OpenFile(file, os.O_WRONLY, 0600)
 	if err != nil {
 		return err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,75 @@
+package config
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/pelletier/go-toml"
+	"github.com/spf13/viper"
+	tm "github.com/tendermint/tendermint/config"
+)
+
+type Config struct {
+	tm.Config  `mapstructure:",squash"`
+	Accumulate Accumulate `mapstructure:",squash"`
+}
+
+type Accumulate struct {
+	RPC    RPC    `toml:"acc-rpc" mapstructure:"acc-rpc"`
+	Router Router `toml:"acc-router" mapstructure:"acc-router"`
+}
+
+type RPC struct {
+	ListenAddress string `toml:"listen-address" mapstructure:"listen-address"`
+}
+
+type Router struct {
+	JSONListenAddress string `toml:"json-listen-address" mapstructure:"json-listen-address"`
+	RESTListenAddress string `toml:"rest-listen-address" mapstructure:"rest-listen-address"`
+}
+
+func Load(dir string) (*Config, error) {
+	return LoadFile(dir, filepath.Join(dir, "config", "config.toml"))
+}
+
+func LoadFile(dir, file string) (*Config, error) {
+	viper.SetConfigFile(file)
+	viper.AddConfigPath(dir)
+	err := viper.ReadInConfig()
+	if err != nil {
+		return nil, fmt.Errorf("read: %v", err)
+	}
+
+	config := &Config{Config: *tm.DefaultConfig()}
+	err = viper.Unmarshal(config)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal: %v", err)
+	}
+
+	config.SetRoot(dir)
+	tm.EnsureRoot(config.RootDir)
+	if err := config.ValidateBasic(); err != nil {
+		return nil, fmt.Errorf("validate: %v", err)
+	}
+	return config, nil
+}
+
+func Store(config *Config) error {
+	// panics on fail
+	tm.WriteConfigFile(config.RootDir, &config.Config)
+
+	f, err := os.OpenFile(filepath.Join(config.RootDir, "config", "config.toml"), os.O_WRONLY, 0600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = f.Seek(0, io.SeekEnd)
+	if err != nil {
+		return err
+	}
+
+	return toml.NewEncoder(f).Encode(config.Accumulate)
+}

--- a/go.mod
+++ b/go.mod
@@ -17,9 +17,7 @@ require (
 	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/gorilla/mux v1.8.0
 	github.com/mitchellh/mapstructure v1.4.2
-	github.com/onsi/ginkgo v1.16.4 // indirect
-	github.com/onsi/gomega v1.13.0 // indirect
-	github.com/pelletier/go-toml v1.9.4 // indirect
+	github.com/pelletier/go-toml v1.9.4
 	github.com/prometheus/common v0.30.0 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
@@ -33,7 +31,7 @@ require (
 	golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d // indirect
 	golang.org/x/sys v0.0.0-20210917161153-d61c044b1678 // indirect
 	golang.org/x/text v0.3.7 // indirect
-	google.golang.org/grpc v1.38.0
+	google.golang.org/grpc v1.40.0
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/ini.v1 v1.63.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -132,6 +132,7 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
+github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/confio/ics23/go v0.0.0-20200817220745-f173e6211efb/go.mod h1:E45NqnlpxGnpfTWL/xauN7MRwEE28T4Dd4uraToOaKg=
@@ -196,6 +197,7 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
+github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/facebookgo/ensure v0.0.0-20160127193407-b4ab57deab51 h1:0JZ+dUmQeA8IIVUMzysrX4/AKuQwWhV2dYQuPZdvdSQ=
 github.com/facebookgo/ensure v0.0.0-20160127193407-b4ab57deab51/go.mod h1:Yg+htXGokKKdzcwhuNDwVvN+uBxDGXJ7G/VN1d8fa64=
@@ -237,7 +239,6 @@ github.com/go-playground/validator/v10 v10.9.0/go.mod h1:74x4gJWsvQexRdW8Pn3dXSG
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/gateway v1.1.0/go.mod h1:S7rR8FRQyG3QFESeSv4l2WnsyzlCLG0CzBbUUo/mbic=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
@@ -467,9 +468,8 @@ github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxzi
 github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
-github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
-github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
@@ -477,17 +477,14 @@ github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:v
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
+github.com/onsi/ginkgo v1.14.0 h1:2mOpI4JVVPBN+WQRa0WKH2eXR+Ey+uK4n7Zj0aYpIQA=
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
-github.com/onsi/ginkgo v1.16.2/go.mod h1:CObGmKUOKaSC0RjmoAK7tKyn4Azo5P2IWuoMnvwxz1E=
-github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
-github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/gomega v1.4.1/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
+github.com/onsi/gomega v1.10.1 h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
-github.com/onsi/gomega v1.13.0 h1:7lLHu94wT9Ij0o6EWWclhu0aOh32VxhkwEJvzuWPeak=
-github.com/onsi/gomega v1.13.0/go.mod h1:lRk9szgn8TxENtWd0Tp4c3wjlRfMTMH27I+3Je41yGY=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
@@ -679,6 +676,7 @@ go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.5/go.mod h1:5pWMHQbX5EPX2/62yrJeAkowc+lfs/XD7Uxpq3pI6kk=
 go.opencensus.io v0.23.0 h1:gqCw0LfLxScz8irSi8exQc7fyQ0fKQU/qnC/X8+V/1M=
 go.opencensus.io v0.23.0/go.mod h1:XItmlyltB5F7CS4xOC1DcqMoFqwtC6OG2xF7mCv7P7E=
+go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.starlark.net v0.0.0-20190702223751-32f345186213/go.mod h1:c1/X6cHgvdXj6pUlmWKMkuqRnW4K8x2vwt6JAaaircg=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
@@ -796,7 +794,6 @@ golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
-golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d h1:20cMwl2fHAzkJMEA+8J4JgqBQcQGzbisXo31MIeenXI=
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
@@ -879,7 +876,6 @@ golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210104204734-6f8348627aad/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -967,7 +963,6 @@ golang.org/x/tools v0.0.0-20201105001634-bc3cf281b174/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20201110124207-079ba7bd75cd/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201201161351-ac6f37ff4c2a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201208233053-a543418bbed2/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
@@ -1081,8 +1076,9 @@ google.golang.org/grpc v1.35.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAG
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.36.1/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.37.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
-google.golang.org/grpc v1.38.0 h1:/9BgsAsa5nWe26HqOlvlgJnqBuktYOLCgjCPqsa56W0=
 google.golang.org/grpc v1.38.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
+google.golang.org/grpc v1.40.0 h1:AGJ0Ih4mHjSeibYkFGh1dD9KJ/eOtZ93I6hoHhukQ5Q=
+google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/networks/networks.go
+++ b/networks/networks.go
@@ -42,7 +42,7 @@ func init() {
 			},
 		},
 		{
-			Name: "LAN",
+			Name: "Localhost",
 			Port: 26656,
 			Ip: []string{
 				"127.0.1.1",

--- a/networks/networks.go
+++ b/networks/networks.go
@@ -10,7 +10,7 @@ var Networks []RouterNode
 
 func init() {
 	Networks = []RouterNode{
-		RouterNode{
+		{
 			Name: "Arches",
 			Port: 33000,
 			Ip: []string{
@@ -18,7 +18,7 @@ func init() {
 				"13.232.230.216",
 			},
 		},
-		RouterNode{
+		{
 			Name: "AmericanSamoa",
 			Port: 33000,
 			Ip: []string{
@@ -26,19 +26,28 @@ func init() {
 				"44.236.45.58",
 			},
 		},
-		RouterNode{
+		{
 			Name: "Badlands",
 			Port: 35550,
 			Ip: []string{
 				"127.0.0.1",
 			},
 		},
-		RouterNode{
+		{
 			Name: "EastXeons",
 			Port: 33000,
 			Ip: []string{
 				"18.119.26.7",
 				"18.119.149.208",
+			},
+		},
+		{
+			Name: "LAN",
+			Port: 26656,
+			Ip: []string{
+				"127.0.1.1",
+				"127.0.1.2",
+				"127.0.1.3",
 			},
 		},
 	}

--- a/router/jsonrpc_test.go
+++ b/router/jsonrpc_test.go
@@ -5,11 +5,13 @@ import (
 	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -24,9 +26,11 @@ import (
 	"github.com/go-playground/validator/v10"
 )
 
+var testnet = flag.Int("testnet", 4, "Testnet to load test")
+
 func TestLoadOnRemote(t *testing.T) {
 
-	networksList := []int{3}
+	networksList := []int{*testnet} // select the localhost testnet
 	txBouncer := networks.MakeBouncer(networksList)
 
 	_, privateKeySponsor, _ := ed25519.GenerateKey(nil)
@@ -50,7 +54,7 @@ func TestLoadOnRemote(t *testing.T) {
 	}
 	fmt.Println(string(output))
 
-	jsonapi := API{RandPort(), validator.New(), query, txBouncer}
+	jsonapi := API{randomRouterPorts(), validator.New(), query, txBouncer}
 	_ = jsonapi
 
 	params := &api.APIRequestURL{URL: types.String(queryTokenUrl)}
@@ -139,8 +143,8 @@ func runLoadTest(t *testing.T, txBouncer *networks.Bouncer, origin *ed25519.Priv
 
 func _TestJsonRpcAnonToken(t *testing.T) {
 	//make a client, and also spin up the router grpc
-	dir, err := ioutil.TempDir("/tmp", "AccRouterTest-")
-	cfg := path.Join(dir, "/Node0/config/config.toml")
+	dir, err := ioutil.TempDir("", "AccRouterTest-")
+	cfg := filepath.Join(dir, "Node0", "config", "config.toml")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -192,7 +196,7 @@ func _TestJsonRpcAnonToken(t *testing.T) {
 	fmt.Println(string(output))
 
 	// now use the JSON rpc api's to get the data
-	jsonapi := API{RandPort(), validator.New(), query, txBouncer}
+	jsonapi := API{randomRouterPorts(), validator.New(), query, txBouncer}
 
 	params := &api.APIRequestURL{URL: types.String(queryTokenUrl)}
 	gParams, err := json.Marshal(params)
@@ -336,7 +340,7 @@ func _TestJsonRpcAdi(t *testing.T) {
 
 	query := NewQuery(txBouncer)
 
-	jsonapi := API{RandPort(), validator.New(), query, txBouncer}
+	jsonapi := API{randomRouterPorts(), validator.New(), query, txBouncer}
 
 	//StartAPI(RandPort(), client)
 

--- a/router/utils_test.go
+++ b/router/utils_test.go
@@ -1,20 +1,26 @@
 package router
 
 import (
+	"fmt"
+
 	"github.com/AccumulateNetwork/accumulated/blockchain/accumulate"
 	"github.com/AccumulateNetwork/accumulated/blockchain/tendermint"
+	"github.com/AccumulateNetwork/accumulated/config"
 	"github.com/spf13/viper"
 	tmnet "github.com/tendermint/tendermint/libs/net"
 	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
 	"github.com/tendermint/tendermint/rpc/client/local"
 )
 
-func RandPort() int {
+func randomRouterPorts() *config.Router {
 	port, err := tmnet.GetFreePort()
 	if err != nil {
 		panic(err)
 	}
-	return port
+	return &config.Router{
+		JSONListenAddress: fmt.Sprintf("localhost:%d", port),
+		RESTListenAddress: fmt.Sprintf("localhost:%d", port+1),
+	}
 }
 
 func boostrapBVC(configfile string, workingdir string, baseport int) error {
@@ -47,7 +53,12 @@ func boostrapBVC(configfile string, workingdir string, baseport int) error {
 }
 
 func makeBVC(configfile string, workingdir string) *tendermint.AccumulatorVMApplication {
-	app, err := accumulate.CreateAccumulateBVC(configfile, workingdir)
+	cfg, err := config.LoadFile(workingdir, configfile)
+	if err != nil {
+		panic(err)
+	}
+
+	app, err := accumulate.CreateAccumulateBVC(cfg)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
**This should be merged after #19**

- Adds `package config` with a `Config` struct containing fields for accumulate-specific configuration
- Refactors `accumulated` to parse config once, passing around a config object instead of passing around the config path and parsing the config multiple times
- Refactors `accumulated` to use properties of the new `config.Config` type, instead of calling Viper directly
- Adds a subcommand, `accumulated testnet`, that generates a localhost testnet

I tested this with `TestLoadOnRemote` and it worked if I decreased the transaction rate. Otherwise I got network timeouts. I think my local machine just can't keep up.