### PR TITLE
Add `--no-empty-blocks` flag to testnet subcommand

### DIFF
--- a/cmd/accumulated/cmd_testnet.go
+++ b/cmd/accumulated/cmd_testnet.go
@@ -20,6 +20,7 @@ var flagTestNet struct {
 	NumValidators int
 	BasePort      int
 	BaseIP        string
+	NoEmptyBlocks bool
 }
 
 func init() {
@@ -28,6 +29,7 @@ func init() {
 	cmdTestNet.Flags().IntVarP(&flagTestNet.NumValidators, "validators", "v", 3, "Number of validator nodes to configure")
 	cmdTestNet.Flags().IntVar(&flagTestNet.BasePort, "port", 26656, "Base port to use for listeners")
 	cmdTestNet.Flags().StringVar(&flagTestNet.BaseIP, "ip", "127.0.1.1", "Base IP address for nodes - must not end with .0")
+	cmdTestNet.Flags().BoolVar(&flagTestNet.NoEmptyBlocks, "no-empty-blocks", false, "Do not create empty blocks")
 }
 
 func initTestNet(cmd *cobra.Command, args []string) {
@@ -60,6 +62,9 @@ func initTestNet(cmd *cobra.Command, args []string) {
 	config := make([]*cfg.Config, flagTestNet.NumValidators)
 	for i := range config {
 		config[i] = cfg.Default()
+		if flagTestNet.NoEmptyBlocks {
+			config[i].Consensus.CreateEmptyBlocks = false
+		}
 	}
 
 	err := node.InitWithConfig(flagMain.WorkDir, "LocalhostTestNet", "LocalhostTestNet", flagTestNet.BasePort, config, IPs, IPs)

--- a/internal/node/init.go
+++ b/internal/node/init.go
@@ -70,7 +70,6 @@ func InitWithConfig(workDir, shardName, chainID string, port int, config []*cfg.
 		config.RPC.GRPCListenAddress = fmt.Sprintf("%s:%d", listenIP[i], port+2)
 		config.Instrumentation.PrometheusListenAddr = fmt.Sprintf(":%d", port)
 
-		config.Consensus.CreateEmptyBlocks = false
 		err = os.MkdirAll(path.Join(nodeDir, "config"), nodeDirPerm)
 		if err != nil {
 			return fmt.Errorf("failed to create config dir: %v", err)


### PR DESCRIPTION
- Reverts a change in the initialization code which results in `config.Consensus.CreateEmptyBlocks` always being set false (the default is true)
- Add a flag to the testnet subcommand to set `config.Consensus.CreateEmptyBlocks = false`, allowing easier testing (less log noise)