### PR TITLE
Add capability to init testnet with followers

### DIFF
--- a/cmd/accumulated/cmd_testnet.go
+++ b/cmd/accumulated/cmd_testnet.go
@@ -18,6 +18,7 @@ var cmdTestNet = &cobra.Command{
 
 var flagTestNet struct {
 	NumValidators int
+	NumFollowers  int
 	BasePort      int
 	BaseIP        string
 	NoEmptyBlocks bool
@@ -26,7 +27,8 @@ var flagTestNet struct {
 func init() {
 	cmdMain.AddCommand(cmdTestNet)
 
-	cmdTestNet.Flags().IntVarP(&flagTestNet.NumValidators, "validators", "v", 3, "Number of validator nodes to configure")
+	cmdTestNet.Flags().IntVarP(&flagTestNet.NumValidators, "validators", "v", 2, "Number of validator nodes to configure")
+	cmdTestNet.Flags().IntVarP(&flagTestNet.NumFollowers, "followers", "f", 1, "Number of follower nodes to configure")
 	cmdTestNet.Flags().IntVar(&flagTestNet.BasePort, "port", 26656, "Base port to use for listeners")
 	cmdTestNet.Flags().StringVar(&flagTestNet.BaseIP, "ip", "127.0.1.1", "Base IP address for nodes - must not end with .0")
 	cmdTestNet.Flags().BoolVar(&flagTestNet.NoEmptyBlocks, "no-empty-blocks", false, "Do not create empty blocks")
@@ -51,7 +53,7 @@ func initTestNet(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	n := flagTestNet.NumValidators
+	n := flagTestNet.NumValidators + flagTestNet.NumFollowers
 	IPs := make([]string, n)
 	config := make([]*cfg.Config, n)
 
@@ -63,7 +65,11 @@ func initTestNet(cmd *cobra.Command, args []string) {
 	}
 
 	for i := range config {
-		config[i] = cfg.DefaultValidator()
+		if i < flagTestNet.NumValidators {
+			config[i] = cfg.DefaultValidator()
+		} else {
+			config[i] = cfg.Default()
+		}
 		if flagTestNet.NoEmptyBlocks {
 			config[i].Consensus.CreateEmptyBlocks = false
 		}


### PR DESCRIPTION
**Before this is merged, #35 must be merged and `AC-287-tendermint-0.35` must be deleted.**

Adds the capability to initialize a local testnet with follower nodes in addition to validator nodes.

The key to getting validators and followers to work together is to ensure that the set of validators includes only validators. Specifically, `<dir>/config/genesis.json` has a `"validators"` array, and Tendermint expects every entry to correspond to a validator node. If one of the entries is actually a follower node, Tendermint consensus will wait for that node to sign proposals and votes, which won't happen (because followers don't sign), so consensus will stall.

I did not add any follower-mode capability to `accumulated init`, because it's not clear how that should work. That's something we should probably have a meeting about.