### PR TITLE
Follower node setup

### DIFF
--- a/cmd/accumulated/cmd_init.go
+++ b/cmd/accumulated/cmd_init.go
@@ -1,30 +1,56 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"strings"
 
+	"github.com/AccumulateNetwork/accumulated/config"
+	cfg "github.com/AccumulateNetwork/accumulated/config"
 	"github.com/AccumulateNetwork/accumulated/internal/node"
 	"github.com/AccumulateNetwork/accumulated/networks"
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
+	tmcfg "github.com/tendermint/tendermint/config"
+	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
+	"github.com/tendermint/tendermint/types"
+	"golang.org/x/term"
 )
 
 const defaultInitNet = "Acadia"
 
 var cmdInit = &cobra.Command{
-	Use:   "init",
+	Use:   "init [follower]",
 	Short: "Initialize node",
 	Run:   initNode,
+}
+
+var cmdInitFollower = &cobra.Command{
+	Use:   "follower",
+	Short: "Initialize follower node",
+	Run:   initFollower,
 }
 
 var flagInit struct {
 	Net string
 }
 
+var flagInitFollower struct {
+	GenesisDoc string
+	ListenIP   string
+}
+
 func init() {
 	cmdMain.AddCommand(cmdInit)
+	cmdInit.AddCommand(cmdInitFollower)
 
-	cmdInit.Flags().StringVarP(&flagInit.Net, "network", "n", defaultInitNet, "Node to build configs for")
+	cmdInit.PersistentFlags().StringVarP(&flagInit.Net, "network", "n", defaultInitNet, "Node to build configs for")
+	cmdInit.MarkFlagRequired("network")
+
+	cmdInitFollower.Flags().StringVar(&flagInitFollower.GenesisDoc, "genesis-doc", "", "Genesis doc for the target network")
+	cmdInitFollower.Flags().StringVar(&flagInitFollower.ListenIP, "listen", "", "Address and port to listen on, e.g. tcp://1.2.3.4:5678")
+	cmdInitFollower.MarkFlagRequired("listen")
 }
 
 func initNode(*cobra.Command, []string) {
@@ -33,7 +59,105 @@ func initNode(*cobra.Command, []string) {
 		fmt.Fprintf(os.Stderr, "Unknown network %q\n", flagInit.Net)
 		os.Exit(1)
 	}
+	network := networks.Networks[i]
 
-	fmt.Printf("Building configs for %s\n", flagInit.Net)
-	node.InitForNetwork("accumulate.", i, flagMain.WorkDir)
+	fmt.Printf("Building configs for %s\n", network.Name)
+
+	listenIP := make([]string, len(network.Ip))
+	config := make([]*cfg.Config, len(network.Ip))
+
+	for i := range network.Ip {
+		listenIP[i] = "tcp://0.0.0.0"
+		config[i] = new(cfg.Config)
+		config[i].Config = *tmcfg.DefaultValidatorConfig()
+	}
+
+	err := node.Init(node.InitOptions{
+		WorkDir:   flagMain.WorkDir,
+		ShardName: "accumulate.",
+		ChainID:   network.Name,
+		Port:      network.Port,
+		Config:    config,
+		RemoteIP:  network.Ip,
+		ListenIP:  listenIP,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func initFollower(cmd *cobra.Command, args []string) {
+	if !strings.HasPrefix(flagInitFollower.ListenIP, "tcp://") {
+		fmt.Fprintf(os.Stderr, "Error: --listen must start with 'tcp://'\n")
+		cmd.Usage()
+		os.Exit(1)
+	}
+
+	i := networks.IndexOf(flagInit.Net)
+	if i < 0 {
+		fmt.Fprintf(os.Stderr, "Error: unknown network %q\n", flagInit.Net)
+		os.Exit(1)
+	}
+	network := networks.Networks[i]
+
+	var genDoc *types.GenesisDoc
+	var err error
+	if cmd.Flag("genesis-doc").Changed {
+		genDoc, err = types.GenesisDocFromFile(flagInitFollower.GenesisDoc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: failed to load genesis doc %q: %v\n", flagInitFollower.GenesisDoc, err)
+			os.Exit(1)
+		}
+	}
+
+	peers := make([]string, len(network.Ip))
+	for i, ip := range network.Ip {
+		client, err := rpchttp.New(fmt.Sprintf("tcp://%s:%d", ip, network.Port+1))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: failed to connect to %s: %v\n", ip, err)
+			os.Exit(1)
+		}
+
+		if genDoc == nil {
+			msg := "WARNING!!! You are fetching the Genesis document from %s! Only do this if you trust %[1]s and your connection to it!\n"
+			if term.IsTerminal(int(os.Stderr.Fd())) {
+				fmt.Fprint(os.Stderr, color.RedString(msg, ip))
+			} else {
+				fmt.Fprintf(os.Stderr, msg, ip)
+			}
+			rgen, err := client.Genesis(context.Background())
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error: failed to get genesis of %s: %v\n", ip, err)
+				os.Exit(1)
+			}
+			genDoc = rgen.Genesis
+		}
+
+		status, err := client.Status(context.Background())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: failed to get status of %s: %v\n", ip, err)
+			os.Exit(1)
+		}
+
+		peers[i] = fmt.Sprintf("%s@%s:%d", status.NodeInfo.NodeID, ip, network.Port)
+	}
+
+	config := config.Default()
+	config.P2P.PersistentPeers = strings.Join(peers, ",")
+
+	err = node.Init(node.InitOptions{
+		WorkDir:    flagMain.WorkDir,
+		ShardName:  "accumulate.",
+		ChainID:    network.Name,
+		Port:       network.Port,
+		GenesisDoc: genDoc,
+		Config:     []*cfg.Config{config},
+		RemoteIP:   []string{""},
+		ListenIP:   []string{flagInitFollower.ListenIP},
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
 }

--- a/cmd/accumulated/cmd_testnet.go
+++ b/cmd/accumulated/cmd_testnet.go
@@ -75,7 +75,15 @@ func initTestNet(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	err := node.InitWithConfig(flagMain.WorkDir, "LocalhostTestNet", "LocalhostTestNet", flagTestNet.BasePort, config, IPs, IPs)
+	err := node.Init(node.InitOptions{
+		WorkDir:   flagMain.WorkDir,
+		ShardName: "LocalhostTestNet",
+		ChainID:   "LocalhostTestNet",
+		Port:      flagTestNet.BasePort,
+		Config:    config,
+		RemoteIP:  IPs,
+		ListenIP:  IPs,
+	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/dgraph-io/badger/v3 v3.2011.1
 	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13 // indirect
 	github.com/dustin/go-humanize v1.0.0
+	github.com/fatih/color v1.13.0
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/go-playground/validator/v10 v10.9.0
 	github.com/golang/protobuf v1.5.2
@@ -33,6 +34,7 @@ require (
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97
 	golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d // indirect
 	golang.org/x/sys v0.0.0-20210917161153-d61c044b1678 // indirect
+	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/grpc v1.40.0
 	google.golang.org/protobuf v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -247,6 +247,8 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/color v1.12.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
+github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
+github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
@@ -568,6 +570,8 @@ github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaO
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
+github.com/mattn/go-colorable v0.1.9 h1:sqDoxXbdeALODt0DAeJCVp38ps9ZogZEAXjus69YV3U=
+github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
@@ -575,6 +579,8 @@ github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2y
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
+github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.6/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
@@ -1135,6 +1141,7 @@ golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210917161153-d61c044b1678 h1:J27LZFQBFoihqXoegpscI10HpjZ7B5WQLLKL2FZXQKw=
 golang.org/x/sys v0.0.0-20210917161153-d61c044b1678/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
Implements `accumulated init follower` subcommand, which will initialize `~/.accumulate/Node0/` as a follower of the specified network. For example, `go run ./cmd/accumulated init follower -n EastXeons --listen tcp://127.0.2.1` will create a follower node that connects to EastXeons.

Doing it this way is potentially unsafe (I think?), because it fetches the genesis doc from the remote node. And since the genesis doc is defines the validators, a middleman or a malicious node could give you bad key info. If you run the command this way, it will warn you that you are pulling the genesis doc from the remote. You can also use a local copy of the genesis doc with the `--genesis` flag (this gets copied into the node's config dir).

I tested this with my localhost testnet (`-n Localhost`) and it worked. I tested it with EastXeons, and it connected and started replaying blocks, but failed during replay. This may have to do with EastXeons running an older version of the code.

In order to avoid replaying the entire history, it may be sufficient to fetch part of the BPT/SMT from the remote and write it to the local state DB. Then, when the follower's Tendermint node starts up, it will pull the latest height and hash from the state DB, and Tendermint won't replay all the blocks. I have not looked into how that could be implemented.