### PR TITLE
Optimize database manager TX cache

### DIFF
--- a/smt/storage/database/cache_test.go
+++ b/smt/storage/database/cache_test.go
@@ -1,0 +1,91 @@
+package database_test
+
+import (
+	"testing"
+
+	"golang.org/x/exp/rand"
+)
+
+type mapVal map[[32]byte]struct{}
+type mapRef map[interface{}]struct{}
+
+const batchSize = 1000
+
+func BenchmarkMap(b *testing.B) {
+	// If the key is a value-type, it will not create GC pressure
+	b.Run("Value-type key", func(b *testing.B) {
+		// Reset by making a new map
+		b.Run("Make", func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				insertVals(make(mapVal, batchSize))
+			}
+		})
+
+		// Reset by deleting all the entries in the map
+		b.Run("Delete", func(b *testing.B) {
+			m := make(mapVal, batchSize)
+			for i := 0; i < b.N; i++ {
+				insertVals(m)
+
+				// The compiler optimizes this (1.11+)
+				for k := range m {
+					delete(m, k)
+				}
+			}
+		})
+	})
+
+	// If the key is a reference-type, the keys must be GC'd
+	b.Run("Reference-type key", func(b *testing.B) {
+		// Reset by making a new map
+		b.Run("Make", func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				insertRefs(mapRef{})
+			}
+		})
+
+		// Reset by deleting all the entries in the map
+		b.Run("Delete", func(b *testing.B) {
+			m := mapRef{}
+			for i := 0; i < b.N; i++ {
+				insertRefs(m)
+
+				// The compiler optimizes this (1.11+)
+				for k := range m {
+					delete(m, k)
+				}
+			}
+		})
+	})
+
+	// How expensive is creating 100 random numbers?
+	b.Run("Only rand", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			for j := 0; j < batchSize; j++ {
+				randKey()
+			}
+		}
+	})
+}
+
+func insertVals(m mapVal) {
+	for i := 0; i < batchSize; i++ {
+		m[randKey()] = struct{}{}
+	}
+}
+
+func insertRefs(m mapRef) {
+	for i := 0; i < batchSize; i++ {
+		m[randKey()] = struct{}{}
+	}
+}
+
+//go:inline
+func randKey() [32]byte {
+	var b [32]byte
+	_, err := rand.Read(b[:])
+	if err != nil {
+		panic(err)
+	}
+	return b
+}

--- a/smt/storage/database/manager.go
+++ b/smt/storage/database/manager.go
@@ -98,6 +98,7 @@ func (m *Manager) init() {
 	m.AddBucket("BPT")          //                       Binary Patricia Tree Byte Blocks (blocks of BPT nodes)
 	m.AddLabel("Root")          //                       The Root node of the BPT
 
+	m.TXCache = make(map[[storage.KeyLength]byte][]byte, 100) // Preallocate 100 slots
 }
 
 // Init
@@ -106,7 +107,6 @@ func (m *Manager) init() {
 // the database is persisted (ignored by memory).PendingChain
 func (m *Manager) Init(databaseTag, filename string) error {
 	m.init()
-	m.TXCache = make(map[[storage.KeyLength]byte][]byte)
 	switch databaseTag { //                              match with a supported databaseTag
 	case "badger": //                                    Badger database indicated
 		m.DB = new(badger.DB)                         // Create a badger struct
@@ -287,11 +287,21 @@ func (m *Manager) EndBatch() {
 	if err := m.DB.EndBatch(m.TXCache); err != nil {
 		panic("batch failed to persist to the database")
 	}
-	m.TXCache = make(map[[storage.KeyLength]byte][]byte, 100) // Reset the List to allow it to be reused
+
+	m.resetCache()
 }
 
 // BeginBatch
 // initializes the batch list to empty.  Note that we really only support one level of batch processing.
 func (m *Manager) BeginBatch() {
-	m.TXCache = make(map[[storage.KeyLength]byte][]byte, 100) // Reset the List to allow it to be reused
+	m.resetCache()
+}
+
+func (m *Manager) resetCache() {
+	// The compiler optimizes away the loop. This is demonstrably faster and
+	// less memory intensive than re-making the map. The savings in GC presure
+	// scale proportionally with the batch size.
+	for k := range m.TXCache {
+		delete(m.TXCache, k)
+	}
 }

--- a/smt/storage/database/manager_test.go
+++ b/smt/storage/database/manager_test.go
@@ -7,13 +7,13 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"math/rand"
 	"os"
 	"testing"
 
 	"github.com/AccumulateNetwork/accumulated/smt/common"
 	"github.com/AccumulateNetwork/accumulated/smt/storage/database"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/rand"
 )
 
 func TestDBManager_TransactionsBadger(t *testing.T) {

--- a/types/state/StateDB_test.go
+++ b/types/state/StateDB_test.go
@@ -38,7 +38,6 @@ func addStateEntry(t *testing.T, sdb *state.StateDB, chainId, txHash, entry stri
 }
 
 func TestStateDBConsistency(t *testing.T) {
-	t.Skip("Test Broken") // ToDo: Broken Test
 	dir := t.TempDir()
 	db := new(badger.DB)
 	err := db.InitDB(filepath.Join(dir, "valacc.db"))


### PR DESCRIPTION
As of Go 1.11, the compiler recognizes clear-map operations (`for k := range m { delete(m, k) }`) and optimizes away the loop. For batch sizes of 100 transactions, using a delete-loop is somewhat faster and reduces the GC pressure by an order of magnitude, as compared to recreating the map (`make(map[key]value, 100)`). The GC pressure difference for a batch size of 1000 is nearly two orders of magnitude. If the map is not preallocated (e.g. `make(map[key]val)` or `map[key]val`), the speed difference is larger.