### PR TITLE
Fix config loading

### DIFF
--- a/cmd/accumulated/cmd_init.go
+++ b/cmd/accumulated/cmd_init.go
@@ -68,7 +68,7 @@ func initNode(*cobra.Command, []string) {
 		listenIP[i] = "tcp://0.0.0.0"
 		remoteIP[i] = net.IP
 		config[i] = new(cfg.Config)
-		config[i].Accumulate.Type = string(network.Type)
+		config[i].Accumulate.Type = network.Type
 
 		switch net.Type {
 		case cfg.Validator:

--- a/config/config.go
+++ b/config/config.go
@@ -42,13 +42,13 @@ type Config struct {
 
 	Accumulate struct {
 		Accumulate `toml:"acc" mapstructure:"acc"`
-	}
+	} `mapstructure:",squash"`
 }
 
 type Accumulate struct {
-	Type      string `toml:"type" mapstructure:"type"` // 'BVC' or 'DC'
-	AccRPC    RPC    `toml:"rpc" mapstructure:"rpc"`
-	AccRouter Router `toml:"router" mapstructure:"router"`
+	Type      NetworkType `toml:"type" mapstructure:"type"` // 'BVC' or 'DC'
+	AccRPC    RPC         `toml:"rpc" mapstructure:"rpc"`
+	AccRouter Router      `toml:"router" mapstructure:"router"`
 }
 
 type RPC struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPersistence(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "config"), 0777))
+
+	// Create
+	cfg := DefaultValidator()
+	cfg.SetRoot(dir)
+	cfg.Accumulate.Type = BVC
+	cfg.Accumulate.AccRPC.ListenAddress = "rpc-listen"
+	cfg.Accumulate.AccRouter.JSONListenAddress = "api-json-listen"
+	cfg.Accumulate.AccRouter.RESTListenAddress = "api-rest-listen"
+
+	// Small changes to make Equal happy
+	cfg.StateSync.RPCServers = []string{}
+
+	// Store
+	require.NoError(t, Store(cfg))
+
+	// Load
+	lcfg, err := Load(dir)
+	require.NoError(t, err)
+
+	// Should be equal
+	require.Equal(t, cfg, lcfg)
+}

--- a/router/utils_test.go
+++ b/router/utils_test.go
@@ -42,7 +42,7 @@ func initOptsForNetwork(t *testing.T, name string) node.InitOptions {
 		listenIP[i] = "tcp://0.0.0.0"
 		remoteIP[i] = net.IP
 		config[i] = new(cfg.Config)
-		config[i].Accumulate.Type = string(network.Type)
+		config[i].Accumulate.Type = network.Type
 
 		switch net.Type {
 		case cfg.Validator:


### PR DESCRIPTION
Fixes a bug in `package config` that prevented Accumulate's configuration from being loaded, leaving the API listen addresses blank. Adds a unit test that should detect any similar bugs in the future.