### PR TITLE
End-to-end test of the ABCI application

### DIFF
--- a/cmd/accumulated/cmd_run.go
+++ b/cmd/accumulated/cmd_run.go
@@ -15,6 +15,7 @@ import (
 	"github.com/AccumulateNetwork/accumulated/types/state"
 	"github.com/spf13/cobra"
 	"github.com/tendermint/tendermint/privval"
+	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
 )
 
 var cmdRun = &cobra.Command{
@@ -69,8 +70,14 @@ func runNode(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
+	rpcClient, err := rpchttp.New(config.RPC.ListenAddress)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: failed to reate RPC client: %v", err)
+		os.Exit(1)
+	}
+
 	bvc := chain.NewBlockValidator()
-	mgr, err := chain.NewManager(config, db, pv.Key.PrivKey.Bytes(), bvc)
+	mgr, err := chain.NewManager(rpcClient, db, pv.Key.PrivKey.Bytes(), bvc)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: failed to initialize chain manager: %v", err)
 		os.Exit(1)

--- a/internal/abci/abci.go
+++ b/internal/abci/abci.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/AccumulateNetwork/accumulated/types/api"
-
 	"github.com/AccumulateNetwork/accumulated/types/api/transactions"
 )
 

--- a/internal/abci/accumulator.go
+++ b/internal/abci/accumulator.go
@@ -63,7 +63,7 @@ func (app *Accumulator) Info(req abci.RequestInfo) abci.ResponseInfo {
 
 // Query implements github.com/tendermint/tendermint/abci/types.Application.
 //
-// Exposed as Tendermint RCP /abci_query.
+// Exposed as Tendermint RPC /abci_query.
 func (app *Accumulator) Query(reqQuery abci.RequestQuery) (resQuery abci.ResponseQuery) {
 	resQuery.Key = reqQuery.Data
 	query := new(api.Query)

--- a/internal/abci/e2e_test.go
+++ b/internal/abci/e2e_test.go
@@ -1,0 +1,195 @@
+package abci_test
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/AccumulateNetwork/accumulated/internal/abci"
+	"github.com/AccumulateNetwork/accumulated/internal/chain"
+	"github.com/AccumulateNetwork/accumulated/types"
+	anon "github.com/AccumulateNetwork/accumulated/types/anonaddress"
+	"github.com/AccumulateNetwork/accumulated/types/api"
+	"github.com/AccumulateNetwork/accumulated/types/api/transactions"
+	"github.com/AccumulateNetwork/accumulated/types/state"
+	"github.com/AccumulateNetwork/accumulated/types/synthetic"
+	"github.com/stretchr/testify/require"
+	abcitypes "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/crypto"
+	tmtypes "github.com/tendermint/tendermint/proto/tendermint/types"
+	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
+	randpkg "golang.org/x/exp/rand"
+)
+
+var rand = randpkg.New(randpkg.NewSource(0))
+var fakeTxid = sha256.Sum256([]byte("fake txid"))
+
+type Tx = transactions.GenTransaction
+
+func TestE2E_Accumulator_AnonToken(t *testing.T) {
+	app := createApp(t)
+
+	_, sponsor, _ := ed25519.GenerateKey(rand)
+	_, recipient, _ := ed25519.GenerateKey(rand)
+
+	appSendTx(t, app, func(send func(*Tx)) {
+		send(createFakeSyntheticDeposit(t, sponsor, recipient))
+	})
+
+	origin := transactions.NewWalletEntry()
+	origin.Nonce = 1
+	origin.PrivateKey = recipient
+	origin.Addr = anon.GenerateAcmeAddress(recipient.Public().(ed25519.PublicKey))
+
+	recipients := make([]*transactions.WalletEntry, 10)
+	for i := range recipients {
+		recipients[i] = transactions.NewWalletEntry()
+	}
+
+	appSendTx(t, app, func(send func(*Tx)) {
+		for i := 0; i < 10; i++ {
+			recipient := recipients[rand.Intn(len(recipients))]
+			output := transactions.Output{Dest: recipient.Addr, Amount: 1000}
+			exch := transactions.NewTokenSend(origin.Addr, output)
+			tx, err := transactions.New(origin, exch)
+			require.NoError(t, err)
+			send(tx)
+		}
+	})
+
+	t.Log(mustJSON(t, appGetChainState(t, app, origin.Addr+"/dc/ACME")))
+}
+
+func BenchmarkE2E_Accumulator_AnonToken(b *testing.B) {
+	app := createApp(b)
+
+	_, sponsor, _ := ed25519.GenerateKey(rand)
+	_, recipient, _ := ed25519.GenerateKey(rand)
+
+	appSendTx(b, app, func(send func(*Tx)) {
+		send(createFakeSyntheticDeposit(b, sponsor, recipient))
+	})
+
+	origin := transactions.NewWalletEntry()
+	origin.Nonce = 1
+	origin.PrivateKey = recipient
+	origin.Addr = anon.GenerateAcmeAddress(recipient.Public().(ed25519.PublicKey))
+
+	rwallet := transactions.NewWalletEntry()
+
+	b.ResetTimer()
+	appSendTx(b, app, func(send func(*Tx)) {
+		for i := 0; i < b.N; i++ {
+			output := transactions.Output{Dest: rwallet.Addr, Amount: 1000}
+			exch := transactions.NewTokenSend(origin.Addr, output)
+			tx, err := transactions.New(origin, exch)
+			require.NoError(b, err)
+			send(tx)
+		}
+	})
+}
+
+func createApp(t testing.TB) abcitypes.Application {
+	_, bvcKey, _ := ed25519.GenerateKey(rand)
+
+	appId := sha256.Sum256([]byte("foo bar"))
+	db := new(state.StateDB)
+	err := db.Open("valacc.db", appId[:], true, true)
+	require.NoError(t, err)
+
+	rpcClient, err := rpchttp.New("tcp://foo.bar:123")
+	require.NoError(t, err)
+
+	bvc := chain.NewBlockValidator()
+	mgr, err := chain.NewManager(rpcClient, db, bvcKey, bvc)
+	require.NoError(t, err)
+
+	app, err := abci.NewAccumulator(db, crypto.Address{}, mgr)
+	require.NoError(t, err)
+
+	return app
+}
+
+func mustJSON(t testing.TB, v interface{}) string {
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(b)
+}
+
+func createFakeSyntheticDeposit(t testing.TB, sponsor, recipient ed25519.PrivateKey) *Tx {
+	t.Helper()
+
+	sponsorAdi := types.String(anon.GenerateAcmeAddress(sponsor.Public().(ed25519.PublicKey)))
+	recipientAdi := types.String(anon.GenerateAcmeAddress(recipient.Public().(ed25519.PublicKey)))
+
+	//create a fake synthetic deposit for faucet.
+	deposit := synthetic.NewTokenTransactionDeposit(fakeTxid[:], &sponsorAdi, &recipientAdi)
+	amtToDeposit := int64(50000)                             //deposit 50k tokens
+	deposit.DepositAmount.SetInt64(amtToDeposit * 100000000) // assume 8 decimal places
+	deposit.TokenUrl = types.String("dc/ACME")
+
+	depData, err := deposit.MarshalBinary()
+	require.NoError(t, err)
+
+	tx := new(Tx)
+	tx.SigInfo = new(transactions.SignatureInfo)
+	tx.Transaction = depData
+	tx.SigInfo.URL = *recipientAdi.AsString()
+	tx.ChainID = types.GetChainIdFromChainPath(recipientAdi.AsString())[:]
+	tx.Routing = types.GetAddressFromIdentity(recipientAdi.AsString())
+
+	ed := new(transactions.ED25519Sig)
+	tx.SigInfo.Nonce = 1
+	ed.PublicKey = recipient.Public().(ed25519.PublicKey)
+	err = ed.Sign(tx.SigInfo.Nonce, recipient, tx.TransactionHash())
+	require.NoError(t, err)
+	tx.Signature = append(tx.Signature, ed)
+	return tx
+}
+
+func appQuery(t testing.TB, app abcitypes.Application, q *api.Query) *api.APIDataResponse {
+	payload, err := q.MarshalBinary()
+	require.NoError(t, err)
+
+	resp := app.Query(abcitypes.RequestQuery{Data: payload})
+	require.Zero(t, resp.Code)
+
+	var msg json.RawMessage = []byte(fmt.Sprintf("{\"entry\":\"%x\"}", resp.Value))
+	chain := new(state.Chain)
+	require.NoError(t, chain.UnmarshalBinary(resp.Value))
+	return &api.APIDataResponse{Type: types.String(chain.Type.Name()), Data: &msg}
+}
+
+func appGetChainState(t testing.TB, app abcitypes.Application, url string) *api.APIDataResponse {
+	q := new(api.Query)
+	q.Url = url
+	q.RouteId = types.GetAddressFromIdentity(&url)
+	q.ChainId = types.GetChainIdFromChainPath(&url).Bytes()
+	return appQuery(t, app, q)
+}
+
+var lastHeight int64
+
+func appSendTx(t testing.TB, app abcitypes.Application, do func(func(*Tx))) {
+	t.Helper()
+
+	lastHeight++
+	app.BeginBlock(abcitypes.RequestBeginBlock{Header: tmtypes.Header{Height: lastHeight, Time: time.Now()}})
+
+	do(func(gtx *Tx) {
+		tx, err := gtx.Marshal()
+		require.NoError(t, err)
+
+		cresp := app.CheckTx(abcitypes.RequestCheckTx{Tx: tx})
+		require.Zero(t, cresp.Code, cresp.Info)
+		dresp := app.DeliverTx(abcitypes.RequestDeliverTx{Tx: tx})
+		require.Zero(t, dresp.Code, dresp.Info)
+	})
+
+	app.EndBlock(abcitypes.RequestEndBlock{})
+
+	app.Commit()
+}

--- a/internal/api/utils_test.go
+++ b/internal/api/utils_test.go
@@ -7,16 +7,16 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/AccumulateNetwork/accumulated/networks"
-
 	cfg "github.com/AccumulateNetwork/accumulated/config"
 	"github.com/AccumulateNetwork/accumulated/internal/abci"
 	"github.com/AccumulateNetwork/accumulated/internal/chain"
 	"github.com/AccumulateNetwork/accumulated/internal/node"
+	"github.com/AccumulateNetwork/accumulated/networks"
 	"github.com/AccumulateNetwork/accumulated/types/state"
 	tmcfg "github.com/tendermint/tendermint/config"
 	tmnet "github.com/tendermint/tendermint/libs/net"
 	"github.com/tendermint/tendermint/privval"
+	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
 )
 
 func randomRouterPorts() *cfg.Router {
@@ -122,8 +122,14 @@ func newBVC(t *testing.T, configfile string, workingdir string) (*cfg.Config, *p
 		t.Fatal(err)
 	}
 
+	rpcClient, err := rpchttp.New(cfg.RPC.ListenAddress)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: failed to reate RPC client: %v", err)
+		os.Exit(1)
+	}
+
 	bvc := chain.NewBlockValidator()
-	mgr, err := chain.NewManager(cfg, sdb, pv.Key.PrivKey.Bytes(), bvc)
+	mgr, err := chain.NewManager(rpcClient, sdb, pv.Key.PrivKey.Bytes(), bvc)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/chain/manager.go
+++ b/internal/chain/manager.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/AccumulateNetwork/accumulated/types/api"
 
-	"github.com/AccumulateNetwork/accumulated/config"
 	"github.com/AccumulateNetwork/accumulated/internal/abci"
 	"github.com/AccumulateNetwork/accumulated/internal/relay"
 	"github.com/AccumulateNetwork/accumulated/smt/common"
@@ -36,22 +35,16 @@ type Manager struct {
 
 var _ abci.Chain = (*Manager)(nil)
 
-func NewManager(config *config.Config, db *state.StateDB, key ed25519.PrivateKey, chain Chain) (*Manager, error) {
+func NewManager(client *rpchttp.HTTP, db *state.StateDB, key ed25519.PrivateKey, chain Chain) (*Manager, error) {
 	m := new(Manager)
 	m.db = db
 	m.chain = chain
 	m.key = key
 	m.wg = new(sync.WaitGroup)
 	m.mu = new(sync.Mutex)
+	m.relay = relay.New(client)
 
 	fmt.Printf("Loaded height=%d hash=%X\n", db.BlockIndex(), db.EnsureRootHash())
-
-	rpcClient, err := rpchttp.New(config.RPC.ListenAddress)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create RPC client: %v", err)
-	}
-	m.relay = relay.New(rpcClient)
-
 	return m, nil
 }
 

--- a/types/api/transactions/tokentransaction.go
+++ b/types/api/transactions/tokentransaction.go
@@ -2,8 +2,9 @@ package transactions
 
 import (
 	"fmt"
-	"github.com/AccumulateNetwork/accumulated/types"
 	"net/url"
+
+	"github.com/AccumulateNetwork/accumulated/types"
 
 	"github.com/AccumulateNetwork/accumulated/smt/common"
 )
@@ -49,6 +50,10 @@ func (t *TokenSend) Marshal() []byte {
 		data = append(data, common.SliceBytes([]byte(v.Dest))...)    //           the destination for the amount
 	}
 	return data
+}
+
+func (t *TokenSend) MarshalBinary() ([]byte, error) {
+	return t.Marshal(), nil
 }
 
 // Unmarshal

--- a/types/state/StateDB.go
+++ b/types/state/StateDB.go
@@ -134,6 +134,9 @@ func (sdb *StateDB) GetPersistentEntry(chainId []byte, verify bool) (*Object, er
 		return nil, fmt.Errorf("database has not been initialized")
 	}
 
+	if debugStateDBWrites {
+		fmt.Printf("Get StateEntries chain=%X\n", chainId)
+	}
 	data := sdb.db.Get("StateEntries", "", chainId)
 
 	if data == nil {


### PR DESCRIPTION
Adds an end-to-end test of the ABCI application, in isolation from Tendermint. This is effectively the same as the load test, but done without starting the Tendermint node.