### PR TITLE
Fix init follower and loadtest

### DIFF
--- a/cmd/accumulated/cmd_init.go
+++ b/cmd/accumulated/cmd_init.go
@@ -120,23 +120,23 @@ func initFollower(cmd *cobra.Command, args []string) {
 	}
 
 	peers := make([]string, len(network.Nodes))
-	for i, ip := range network.Nodes {
-		client, err := rpchttp.New(fmt.Sprintf("tcp://%s:%d", ip, network.Port+1))
+	for i, n := range network.Nodes {
+		client, err := rpchttp.New(fmt.Sprintf("tcp://%s:%d", n.IP, network.Port+node.TmRpcPortOffset))
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: failed to connect to %s: %v\n", ip, err)
+			fmt.Fprintf(os.Stderr, "Error: failed to connect to %s: %v\n", n.IP, err)
 			os.Exit(1)
 		}
 
 		if genDoc == nil {
 			msg := "WARNING!!! You are fetching the Genesis document from %s! Only do this if you trust %[1]s and your connection to it!\n"
 			if term.IsTerminal(int(os.Stderr.Fd())) {
-				fmt.Fprint(os.Stderr, color.RedString(msg, ip))
+				fmt.Fprint(os.Stderr, color.RedString(msg, n.IP))
 			} else {
-				fmt.Fprintf(os.Stderr, msg, ip)
+				fmt.Fprintf(os.Stderr, msg, n.IP)
 			}
 			rgen, err := client.Genesis(context.Background())
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error: failed to get genesis of %s: %v\n", ip, err)
+				fmt.Fprintf(os.Stderr, "Error: failed to get genesis of %s: %v\n", n.IP, err)
 				os.Exit(1)
 			}
 			genDoc = rgen.Genesis
@@ -144,11 +144,11 @@ func initFollower(cmd *cobra.Command, args []string) {
 
 		status, err := client.Status(context.Background())
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: failed to get status of %s: %v\n", ip, err)
+			fmt.Fprintf(os.Stderr, "Error: failed to get status of %s: %v\n", n, err)
 			os.Exit(1)
 		}
 
-		peers[i] = fmt.Sprintf("%s@%s:%d", status.NodeInfo.NodeID, ip, network.Port)
+		peers[i] = fmt.Sprintf("%s@%s:%d", status.NodeInfo.NodeID, n.IP, network.Port)
 	}
 
 	config := config.Default()

--- a/cmd/accumulated/cmd_loadtest.go
+++ b/cmd/accumulated/cmd_loadtest.go
@@ -61,7 +61,7 @@ func loadTest(cmd *cobra.Command, args []string) {
 			os.Exit(1)
 		}
 
-		lAddr := fmt.Sprintf("tcp://%s:%d", net.Nodes[0], net.Port+node.TmRpcPortOffset)
+		lAddr := fmt.Sprintf("tcp://%s:%d", net.Nodes[0].IP, net.Port+node.TmRpcPortOffset)
 		client, err := rpc.New(lAddr)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: failed to create RPC client for network %q: %v\n", name, err)


### PR DESCRIPTION
`accumulated init follower` and `accumulated loadtest` were broken by AC-347. This fixes it.