### PR TITLE
Move query and transaction marshalling to api.Query

### DIFF
--- a/cmd/accumulated/cmd_loadtest.go
+++ b/cmd/accumulated/cmd_loadtest.go
@@ -100,10 +100,11 @@ func loadTest(cmd *cobra.Command, args []string) {
 	}
 
 	relay := relay.New(clients...)
+	query := api.NewQuery(relay)
 
 	_, privateKeySponsor, _ := ed25519.GenerateKey(nil)
 
-	addrList, err := acctesting.RunLoadTest(relay, &privateKeySponsor, flagLoadTest.WalletCount, flagLoadTest.WalletCount*flagLoadTest.TransactionCount)
+	addrList, err := acctesting.RunLoadTest(query, &privateKeySponsor, flagLoadTest.WalletCount, flagLoadTest.WalletCount*flagLoadTest.TransactionCount)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
@@ -111,7 +112,6 @@ func loadTest(cmd *cobra.Command, args []string) {
 
 	time.Sleep(10000 * time.Millisecond)
 
-	query := api.NewQuery(relay)
 	for _, v := range addrList[1:] {
 		resp, err := query.GetChainState(&v, nil)
 		if err != nil {

--- a/cmd/accumulated/cmd_run.go
+++ b/cmd/accumulated/cmd_run.go
@@ -76,8 +76,9 @@ func runNode(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
+	query := api.NewQuery(relay.New(rpcClient))
 	bvc := chain.NewBlockValidator()
-	mgr, err := chain.NewManager(rpcClient, db, pv.Key.PrivKey.Bytes(), bvc)
+	mgr, err := chain.NewManager(query, db, pv.Key.PrivKey.Bytes(), bvc)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: failed to initialize chain manager: %v", err)
 		os.Exit(1)
@@ -110,9 +111,9 @@ func runNode(cmd *cobra.Command, args []string) {
 	}
 
 	// The query object connects to the BVC, will be replaced with network client router
-	query := api.NewQuery(txRelay)
+	query = api.NewQuery(txRelay)
 
-	api.StartAPI(&config.Accumulate.API, query, txRelay)
+	api.StartAPI(&config.Accumulate.API, query)
 
 	// Block forever
 	select {}

--- a/internal/abci/e2e_test.go
+++ b/internal/abci/e2e_test.go
@@ -9,7 +9,9 @@ import (
 	"time"
 
 	"github.com/AccumulateNetwork/accumulated/internal/abci"
+	accapi "github.com/AccumulateNetwork/accumulated/internal/api"
 	"github.com/AccumulateNetwork/accumulated/internal/chain"
+	"github.com/AccumulateNetwork/accumulated/internal/relay"
 	"github.com/AccumulateNetwork/accumulated/types"
 	anon "github.com/AccumulateNetwork/accumulated/types/anonaddress"
 	"github.com/AccumulateNetwork/accumulated/types/api"
@@ -104,7 +106,7 @@ func createApp(t testing.TB) abcitypes.Application {
 	require.NoError(t, err)
 
 	bvc := chain.NewBlockValidator()
-	mgr, err := chain.NewManager(rpcClient, db, bvcKey, bvc)
+	mgr, err := chain.NewManager(accapi.NewQuery(relay.New(rpcClient)), db, bvcKey, bvc)
 	require.NoError(t, err)
 
 	app, err := abci.NewAccumulator(db, crypto.Address{}, mgr)

--- a/internal/api/jsonrpc.go
+++ b/internal/api/jsonrpc.go
@@ -11,7 +11,6 @@ import (
 	"os"
 
 	"github.com/AccumulateNetwork/accumulated/config"
-	"github.com/AccumulateNetwork/accumulated/internal/relay"
 	"github.com/AccumulateNetwork/accumulated/types"
 	anon "github.com/AccumulateNetwork/accumulated/types/anonaddress"
 	acmeapi "github.com/AccumulateNetwork/accumulated/types/api"
@@ -23,21 +22,19 @@ import (
 )
 
 type API struct {
-	config    *config.API
-	validate  *validator.Validate
-	query     *Query
-	txBouncer *relay.Relay
+	config   *config.API
+	validate *validator.Validate
+	query    *Query
 }
 
 // StartAPI starts new JSON-RPC server
-func StartAPI(config *config.API, q *Query, txBouncer *relay.Relay) *API {
+func StartAPI(config *config.API, q *Query) *API {
 
 	// fmt.Printf("Starting JSON-RPC API at http://localhost:%d\n", port)
 
 	api := &API{}
 	api.validate = validator.New()
 	api.query = q
-	api.txBouncer = txBouncer
 
 	methods := jsonrpc2.MethodMap{
 		// URL
@@ -285,12 +282,13 @@ func (api *API) sendTx(req *acmeapi.APIRequestRaw, payload []byte) *acmeapi.APID
 		ret.Data = &msg
 		return ret
 	}
-	resp, err := api.txBouncer.SendTx(genTx)
+	resp, err := api.query.BroadcastTx(genTx)
 	if err != nil {
 		msg = []byte(fmt.Sprintf("{\"error\":\"%v\"}", err))
 		ret.Data = &msg
 		return ret
 	}
+	api.query.BatchSend()
 
 	msg = []byte(fmt.Sprintf("{\"txid\":\"%x\",\"log\":\"%s\"}", genTx.TransactionHash(), resp.Log))
 	ret.Data = &msg
@@ -452,11 +450,11 @@ func (api *API) faucet(_ context.Context, params json.RawMessage) interface{} {
 
 	gtx.Signature = append(gtx.Signature, ed)
 
-	resp, err := api.txBouncer.SendTx(gtx)
-
+	resp, err := api.query.BroadcastTx(gtx)
 	if err != nil {
 		return NewAccumulateError(err)
 	}
+	api.query.BatchSend()
 
 	ret := acmeapi.APIDataResponse{}
 	ret.Type = "faucet"

--- a/internal/api/query_test.go
+++ b/internal/api/query_test.go
@@ -1,4 +1,4 @@
-package api
+package api_test
 
 import (
 	"testing"

--- a/internal/api/testutils_test.go
+++ b/internal/api/testutils_test.go
@@ -1,4 +1,4 @@
-package api
+package api_test
 
 import (
 	"crypto/sha256"

--- a/internal/api/utils2_test.go
+++ b/internal/api/utils2_test.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	cfg "github.com/AccumulateNetwork/accumulated/config"
+	"github.com/go-playground/validator/v10"
+	tmnet "github.com/tendermint/tendermint/libs/net"
+)
+
+func NewTest(q *Query) *API {
+	return &API{randomRouterPorts(), validator.New(), q}
+}
+
+func randomRouterPorts() *cfg.API {
+	port, err := tmnet.GetFreePort()
+	if err != nil {
+		panic(err)
+	}
+	return &cfg.API{
+		JSONListenAddress: fmt.Sprintf("localhost:%d", port),
+		RESTListenAddress: fmt.Sprintf("localhost:%d", port+1),
+	}
+}
+
+func (api *API) GetData(ctx context.Context, params json.RawMessage) interface{} {
+	return api.getData(ctx, params)
+}
+
+func (api *API) CreateADI(ctx context.Context, params json.RawMessage) interface{} {
+	return api.createADI(ctx, params)
+}

--- a/internal/api/utils_test.go
+++ b/internal/api/utils_test.go
@@ -1,4 +1,4 @@
-package api
+package api_test
 
 import (
 	"crypto/sha256"
@@ -9,26 +9,16 @@ import (
 
 	cfg "github.com/AccumulateNetwork/accumulated/config"
 	"github.com/AccumulateNetwork/accumulated/internal/abci"
+	"github.com/AccumulateNetwork/accumulated/internal/api"
 	"github.com/AccumulateNetwork/accumulated/internal/chain"
 	"github.com/AccumulateNetwork/accumulated/internal/node"
+	"github.com/AccumulateNetwork/accumulated/internal/relay"
 	"github.com/AccumulateNetwork/accumulated/networks"
 	"github.com/AccumulateNetwork/accumulated/types/state"
 	tmcfg "github.com/tendermint/tendermint/config"
-	tmnet "github.com/tendermint/tendermint/libs/net"
 	"github.com/tendermint/tendermint/privval"
 	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
 )
-
-func randomRouterPorts() *cfg.API {
-	port, err := tmnet.GetFreePort()
-	if err != nil {
-		panic(err)
-	}
-	return &cfg.API{
-		JSONListenAddress: fmt.Sprintf("localhost:%d", port),
-		RESTListenAddress: fmt.Sprintf("localhost:%d", port+1),
-	}
-}
 
 func initOptsForNetwork(t *testing.T, name string) node.InitOptions {
 	t.Helper()
@@ -130,7 +120,7 @@ func newBVC(t *testing.T, workingdir string) (*cfg.Config, *privval.FilePV, *nod
 	}
 
 	bvc := chain.NewBlockValidator()
-	mgr, err := chain.NewManager(rpcClient, sdb, pv.Key.PrivKey.Bytes(), bvc)
+	mgr, err := chain.NewManager(api.NewQuery(relay.New(rpcClient)), sdb, pv.Key.PrivKey.Bytes(), bvc)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -2,12 +2,16 @@ package relay
 
 import (
 	"context"
+	"fmt"
+
 	"github.com/AccumulateNetwork/accumulated/types/api"
 
 	"github.com/AccumulateNetwork/accumulated/types"
 	"github.com/AccumulateNetwork/accumulated/types/api/transactions"
+	"github.com/tendermint/tendermint/libs/bytes"
 	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
+	tmtypes "github.com/tendermint/tendermint/types"
 )
 
 // Relay is the structure used to relay messages to the correct BVC.  Transactions can either be batched and dispatched
@@ -27,41 +31,39 @@ func New(clients ...*rpchttp.HTTP) *Relay {
 }
 
 // initialize will set the initial clients and create a new batch for each client
-func (b *Relay) initialize(clients []*rpchttp.HTTP) error {
-	b.rpcClient = clients
-	b.numNetworks = len(clients)
-	b.resetBatches()
-
-	return nil
+func (r *Relay) initialize(clients []*rpchttp.HTTP) {
+	r.rpcClient = clients
+	r.numNetworks = len(clients)
+	r.resetBatches()
 }
 
 // resetBatches gets called after each call to BatchSend().  It will thread off the batch of transactions it has, then
 // create a new batch by calling this function
-func (b *Relay) resetBatches() {
-	b.batches = make([]*rpchttp.BatchHTTP, b.numNetworks)
-	for i := range b.batches {
-		b.batches[i] = b.rpcClient[i].NewBatch()
+func (r *Relay) resetBatches() {
+	r.batches = make([]*rpchttp.BatchHTTP, r.numNetworks)
+	for i := range r.batches {
+		r.batches[i] = r.rpcClient[i].NewBatch()
 	}
 }
 
-func (b *Relay) BatchTx(tx *transactions.GenTransaction) (*ctypes.ResultBroadcastTx, error) {
-	data, err := tx.Marshal()
+func (r *Relay) BatchTx(tx tmtypes.Tx) (*ctypes.ResultBroadcastTx, error) {
+	gtx, err := decodeTX(tx)
 	if err != nil {
 		return nil, err
 	}
-	return b.batches[int(tx.Routing)%b.numNetworks].BroadcastTxAsync(context.Background(), data)
+	return r.batches[int(gtx.Routing)%r.numNetworks].BroadcastTxAsync(context.Background(), tx)
 }
 
 // BatchSend
 // This will dispatch all the transactions that have been put into batches. The calling function does not have to
 // wait for batch to be sent.  This is a fire and forget operation
-func (b *Relay) BatchSend() {
-	sendBatches := make([]*rpchttp.BatchHTTP, b.numNetworks)
-	for i, batch := range b.batches {
+func (r *Relay) BatchSend() {
+	sendBatches := make([]*rpchttp.BatchHTTP, r.numNetworks)
+	for i, batch := range r.batches {
 		sendBatches[i] = batch
 	}
 	go dispatch(sendBatches)
-	b.resetBatches()
+	r.resetBatches()
 }
 
 // dispatch
@@ -80,29 +82,42 @@ func dispatch(batches []*rpchttp.BatchHTTP) {
 // SendTx
 // This function will send an individual transaction and return the result.  However, this is a broadcast asynchronous
 // call to tendermint, so it won't provide tendermint results from CheckTx or DeliverTx
-func (b *Relay) SendTx(tx *transactions.GenTransaction) (*ctypes.ResultBroadcastTx, error) {
-	data, err := tx.Marshal()
+func (r *Relay) SendTx(tx tmtypes.Tx) (*ctypes.ResultBroadcastTx, error) {
+	gtx, err := decodeTX(tx)
 	if err != nil {
 		return nil, err
 	}
-	return b.rpcClient[int(tx.Routing)%b.numNetworks].BroadcastTxSync(context.Background(), data)
+	return r.rpcClient[int(gtx.Routing)%r.numNetworks].BroadcastTxSync(context.Background(), tx)
 }
 
 // Query
 // This function will return the state object from the accumulate network for a given URL.
-func (b *Relay) Query(url *string, txId []byte) (ret *ctypes.ResultABCIQuery, err error) {
-	addr := types.GetAddressFromIdentity(url)
-
-	pq := api.Query{}
-	pq.Url = *url
-	pq.RouteId = addr
-	pq.ChainId = types.GetChainIdFromChainPath(url).Bytes()
-	pq.Content = txId
-
-	data, err := pq.MarshalBinary()
+func (r *Relay) Query(data bytes.HexBytes) (ret *ctypes.ResultABCIQuery, err error) {
+	_, addr, err := decodeQuery(data)
 	if err != nil {
 		return nil, err
 	}
+	return r.rpcClient[addr%uint64(r.numNetworks)].ABCIQuery(context.Background(), "/abci_query", data)
+}
 
-	return b.rpcClient[addr%uint64(b.numNetworks)].ABCIQuery(context.Background(), "/abci_query", data)
+func decodeTX(tx tmtypes.Tx) (*transactions.GenTransaction, error) {
+	gtx := new(transactions.GenTransaction)
+	next, err := gtx.UnMarshal(tx)
+	if err != nil {
+		return nil, err
+	}
+	if len(next) > 0 {
+		return nil, fmt.Errorf("got %d extra byte(s)", len(next))
+	}
+	return gtx, nil
+}
+
+func decodeQuery(data bytes.HexBytes) (*api.Query, uint64, error) {
+	query := new(api.Query)
+	err := query.UnmarshalBinary(data)
+	if err != nil {
+		return nil, 0, err
+	}
+	addr := types.GetAddressFromIdentity(&query.Url)
+	return query, addr, nil
 }


### PR DESCRIPTION
Change relay.Relay to accept Tendermint transactions to allow for decoupling `relay.Relay`, `api.Query`, and `rpchttp.HTTP`. This will allow the relay and API to be tested independently, and will allow more flexibility and code reuse.