### PR TITLE
Embed version info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+all: build
+
+# Go handles build caching, so Go targets should always be marked phony.
+.PHONY: all build
+
+build:
+	go build -ldflags "-X 'github.com/AccumulateNetwork/accumulated.Version=$(shell git describe --dirty)'" ./cmd/accumulated
+
+install:
+	go install -ldflags "-X 'github.com/AccumulateNetwork/accumulated.Version=$(shell git describe --dirty)'" ./cmd/accumulated

--- a/cmd/accumulated/cmd_version.go
+++ b/cmd/accumulated/cmd_version.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/AccumulateNetwork/accumulated"
+	"github.com/spf13/cobra"
+)
+
+var cmdVersion = &cobra.Command{
+	Use: "version",
+	Run: showVersion,
+}
+
+var flagVersion struct {
+	VersionOnly  bool
+	KnownVersion bool
+}
+
+func init() {
+	cmdMain.AddCommand(cmdVersion)
+
+	cmdVersion.Flags().BoolVar(&flagVersion.VersionOnly, "version-only", false, "Only print out the version number")
+	cmdVersion.Flags().BoolVar(&flagVersion.KnownVersion, "known-version", false, "Return 1 if the version number is unknown")
+}
+
+func showVersion(*cobra.Command, []string) {
+	if flagVersion.KnownVersion && !accumulated.IsVersionKnown() {
+		defer os.Exit(1)
+	} else {
+		defer os.Exit(0)
+	}
+
+	if flagVersion.VersionOnly {
+		fmt.Println(accumulated.Version)
+		return
+	}
+
+	fmt.Printf("%s %s\n", cmdMain.Short, accumulated.Version)
+}

--- a/version.go
+++ b/version.go
@@ -1,0 +1,9 @@
+package accumulated
+
+const unknownVersion = "version unknown"
+
+var Version = unknownVersion
+
+func IsVersionKnown() bool {
+	return Version != unknownVersion
+}


### PR DESCRIPTION
Embeds version info, when built with `make`, which is exposed via `accumulated version` and via the `/abci_info` RPC call. This can be used to show which commit a given node is running.