### PR TITLE
Do not double query

### DIFF
--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -1,18 +1,14 @@
 package api
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/AccumulateNetwork/accumulated/internal/relay"
-	"github.com/AccumulateNetwork/accumulated/smt/common"
 	"github.com/AccumulateNetwork/accumulated/types"
 	"github.com/AccumulateNetwork/accumulated/types/api"
 	acmeApi "github.com/AccumulateNetwork/accumulated/types/api"
 	"github.com/AccumulateNetwork/accumulated/types/api/response"
 	"github.com/AccumulateNetwork/accumulated/types/api/transactions"
-	"github.com/AccumulateNetwork/accumulated/types/state"
-	tmtypes "github.com/tendermint/tendermint/abci/types"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 )
 
@@ -65,134 +61,33 @@ func (q *Query) BatchSend() {
 
 // GetAdi get the adi state object. Use this to get the nonce.
 func (q *Query) GetAdi(adi *string) (*acmeApi.APIDataResponse, error) {
-
-	var err error
-	if err != nil {
-		return nil, fmt.Errorf("cannot marshal query for Token issuance")
-	}
-
-	aResp, err := q.Query(*adi, nil)
-
+	r, err := q.Query(*adi, nil)
 	if err != nil {
 		return nil, fmt.Errorf("bvc adi query returned error, %v", err)
 	}
 
-	qResp := aResp.Response
-
-	if err != nil {
-		return nil, fmt.Errorf("bvc adi query returned error, %v", err)
-	}
-
-	//unpack the response
-	ret := &acmeApi.APIDataResponse{}
-	ret.Type = "adi"
-
-	if qResp.Code == 0 {
-		//unpack the state object returned from the query
-		adiResp := response.ADI{}
-		err = adiResp.ADI.UnmarshalBinary(qResp.Value)
-
-		//package the response data into json
-		var data json.RawMessage
-		data, err = json.Marshal(adiResp)
-		if err != nil {
-			return nil, fmt.Errorf("cannot extract token information")
-		}
-
-		ret.Data = &data
-	} else {
-		var data json.RawMessage
-		data, err = json.Marshal(qResp.Value)
-		ret.Data = &data
-	}
-
-	return ret, err
+	return unmarshalADI(r.Response)
 }
 
 // GetToken
 // retrieve the informatin regarding a token
 func (q *Query) GetToken(tokenUrl *string) (*acmeApi.APIDataResponse, error) {
-
-	var err error
-	aResp, err := q.Query(*tokenUrl, nil)
-
+	r, err := q.Query(*tokenUrl, nil)
 	if err != nil {
 		return nil, fmt.Errorf("bvc token query returned error, %v", err)
 	}
-	qResp := aResp.Response
 
-	//unpack the response
-
-	ret := &acmeApi.APIDataResponse{}
-	ret.Type = "token"
-
-	if qResp.Code == 0 {
-
-		//unpack the state object returned from the query
-		tokState := &state.Token{}
-		err = tokState.UnmarshalBinary(qResp.Value)
-
-		tokResp := response.Token{}
-
-		tokResp.Precision = tokState.Precision
-		tokResp.URL = tokState.ChainUrl
-		tokResp.Symbol = tokState.Symbol
-		tokResp.Meta = tokState.Meta
-		//package the response data into json
-		var data json.RawMessage
-		data, err = json.Marshal(tokResp)
-		if err != nil {
-			return nil, fmt.Errorf("cannot extract token information")
-		}
-
-		ret.Data = &data
-	} else {
-		var data json.RawMessage
-		data, err = json.Marshal(qResp.Value)
-		ret.Data = &data
-	}
-
-	return ret, err
+	return unmarshalToken(r.Response)
 }
 
 // GetTokenAccount get the token balance for a given url
 func (q *Query) GetTokenAccount(adiChainPath *string) (*acmeApi.APIDataResponse, error) {
-
-	var err error
-
-	aResp, err := q.Query(*adiChainPath, nil)
-
+	r, err := q.Query(*adiChainPath, nil)
 	if err != nil {
 		return nil, fmt.Errorf("bvc token account query returned error, %v", err)
 	}
-	qResp := aResp.Response
 
-	ret := &acmeApi.APIDataResponse{}
-	ret.Type = "tokenAccount"
-
-	if qResp.Code == 0 {
-
-		//unpack the state object returned from the query
-		tokState := &state.TokenAccount{}
-		err = tokState.UnmarshalBinary(qResp.Value)
-
-		ta := acmeApi.NewTokenAccount(tokState.ChainUrl, tokState.TokenUrl.String)
-		tokResp := response.NewTokenAccount(ta, tokState.GetBalance())
-		//package the response data into json
-		var data json.RawMessage
-		data, err = json.Marshal(tokResp)
-		if err != nil {
-			return nil, fmt.Errorf("cannot extract token information")
-		}
-
-		ret.Data = &data
-	} else {
-		var data json.RawMessage
-		data, err = json.Marshal(qResp.Value)
-		ret.Data = &data
-	}
-
-	return ret, err
+	return unmarshalTokenAccount(r.Response)
 }
 
 // GetTokenTx
@@ -200,34 +95,25 @@ func (q *Query) GetTokenAccount(adiChainPath *string) (*acmeApi.APIDataResponse,
 func (q *Query) GetTokenTx(tokenAccountUrl *string, txId []byte) (resp interface{}, err error) {
 	// need to know the ADI and ChainID, deriving adi and chain id from TokenTx.From
 
-	aResp, err := q.Query(*tokenAccountUrl, txId)
+	// TODO Why does this return a response.TokenTx instead of api.APIDataResponse?
 
+	r, err := q.Query(*tokenAccountUrl, txId)
 	if err != nil {
 		return nil, fmt.Errorf("bvc token tx query returned error, %v", err)
 	}
-	qResp := aResp.Response
 
-	data, txRaw := common.BytesSlice(qResp.Value)
-	data, txPending := common.BytesSlice(data)
-	_ = txPending
-	txState := state.Transaction{}
-	err = txState.UnmarshalBinary(txRaw)
+	tx, err := unmarshalTokenTx(r.Response)
 	if err != nil {
-		return resp, NewAccumulateError(err)
+		return nil, err
 	}
-	//now unmarshal the token transaction on-chain
-	//need to identify type of TX, for now only support token tx
-	tx := transactions.TokenSend{}
-	_, err = tx.Unmarshal(txState.Transaction.Bytes())
-	if err != nil {
-		return resp, NewAccumulateError(err)
-	}
-	txResp := response.TokenTx{}
-	txResp.FromUrl = types.String(*tokenAccountUrl)
-	copy(txResp.TxId[:], txId)
+
+	rTx := new(response.TokenTx)
+	rTx.FromUrl = types.String(*tokenAccountUrl)
+	copy(rTx.TxId[:], txId)
 
 	//should receive tx,unmarshal to output accounts
 	for _, v := range tx.Outputs {
+		// TODO What is the purpose of this? It's executing the same query, repeatedly.
 		aResp, err := q.Query(*tokenAccountUrl, txId)
 
 		txStatus := response.TokenTxAccountStatus{}
@@ -235,7 +121,7 @@ func (q *Query) GetTokenTx(tokenAccountUrl *string, txId []byte) (resp interface
 			txStatus.Status = types.String(fmt.Sprintf("transaction not found for %s, %v", v.Dest, err))
 			txStatus.AccountUrl = types.String(v.Dest)
 		} else {
-			qResp = aResp.Response
+			qResp := aResp.Response
 			err = txStatus.UnmarshalBinary(qResp.Value)
 			if err != nil {
 				txStatus.Status = types.String(fmt.Sprintf("%v", err))
@@ -243,69 +129,21 @@ func (q *Query) GetTokenTx(tokenAccountUrl *string, txId []byte) (resp interface
 			}
 		}
 
-		txResp.ToAccount = append(txResp.ToAccount, txStatus)
+		rTx.ToAccount = append(rTx.ToAccount, txStatus)
 	}
 
-	return txResp, err
-}
-
-var ChainStates = map[types.ChainType]interface{}{
-	types.ChainTypeAdi: func(q *Query, url *string, txid []byte) (*acmeApi.APIDataResponse, error) {
-		return q.GetAdi(url)
-	},
-	types.ChainTypeToken: func(q *Query, url *string, txid []byte) (*acmeApi.APIDataResponse, error) {
-		return q.GetToken(url)
-	},
-	types.ChainTypeTokenAccount: func(q *Query, url *string, txid []byte) (*acmeApi.APIDataResponse, error) {
-		return q.GetTokenAccount(url)
-	},
-	types.ChainTypeSignatureGroup: func(q *Query, url *string, txid []byte) (*acmeApi.APIDataResponse, error) {
-		return q.GetTokenAccount(url)
-	},
-	types.ChainTypeAnonTokenAccount: func(q *Query, url *string, txid []byte) (*acmeApi.APIDataResponse, error) {
-		adi, _, _ := types.ParseIdentityChainPath(url)
-		adi += "/dc/ACME"
-		return q.GetTokenAccount(&adi)
-	},
+	return rTx, err
 }
 
 // GetChainState
 // will return the state object of the chain, which include the chain
 // header and the current state data for the chain
-func (q *Query) GetChainState(adiChainPath *string, txId []byte) (interface{}, error) {
-	var err error
-
-	var qResp *tmtypes.ResponseQuery
-
+func (q *Query) GetChainState(adiChainPath *string, txId []byte) (*api.APIDataResponse, error) {
 	//this QuerySync call is only temporary until we get router setup.
-	aResp, err := q.Query(*adiChainPath, txId)
+	r, err := q.Query(*adiChainPath, txId)
 	if err != nil {
 		return nil, fmt.Errorf("bvc token chain query returned error, %v", err)
 	}
-	qResp = &aResp.Response
 
-	var resp *acmeApi.APIDataResponse
-	if len(txId) == 0 {
-		chainHeader := state.Chain{}
-
-		err = chainHeader.UnmarshalBinary(qResp.Value)
-
-		if err != nil {
-			return nil, fmt.Errorf("invalid state object returned from query of url %s, %v", *adiChainPath, err)
-		}
-
-		//unmarshal the state object if available
-		if val, ok := ChainStates[chainHeader.Type]; ok {
-			//resp, err = val.(func([]byte) (interface{}, error))(qResp.Value)
-			resp, err = val.(func(*Query, *string, []byte) (*acmeApi.APIDataResponse, error))(q, chainHeader.ChainUrl.AsString(), []byte{})
-		} else {
-			resp = &acmeApi.APIDataResponse{}
-			resp.Type = types.String(chainHeader.Type.Name())
-			msg := json.RawMessage{}
-			msg = []byte(fmt.Sprintf("{\"entry\":\"%x\"}", qResp.Value))
-			resp.Data = &msg
-		}
-	}
-
-	return resp, err
+	return q.unmarshalByType(r.Response)
 }

--- a/internal/api/unmarshal.go
+++ b/internal/api/unmarshal.go
@@ -1,0 +1,122 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/AccumulateNetwork/accumulated/smt/common"
+	"github.com/AccumulateNetwork/accumulated/types"
+	"github.com/AccumulateNetwork/accumulated/types/api"
+	"github.com/AccumulateNetwork/accumulated/types/api/response"
+	"github.com/AccumulateNetwork/accumulated/types/api/transactions"
+	"github.com/AccumulateNetwork/accumulated/types/state"
+	tm "github.com/tendermint/tendermint/abci/types"
+)
+
+func unmarshalAs(rQuery tm.ResponseQuery, typ string, as func([]byte) (interface{}, error)) (*api.APIDataResponse, error) {
+	rAPI := new(api.APIDataResponse)
+	rAPI.Type = types.String(typ)
+
+	if rQuery.Code != 0 {
+		data, err := json.Marshal(rQuery.Value)
+		if err != nil {
+			return nil, err
+		}
+
+		rAPI.Data = (*json.RawMessage)(&data)
+		return rAPI, nil
+	}
+
+	v, err := as(rQuery.Value)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+
+	rAPI.Data = (*json.RawMessage)(&data)
+	return rAPI, nil
+}
+
+func unmarshalADI(rQuery tm.ResponseQuery) (*api.APIDataResponse, error) {
+	return unmarshalAs(rQuery, "adi", func(b []byte) (interface{}, error) {
+		adi := new(response.ADI)
+		err := adi.ADI.UnmarshalBinary(b)
+		return adi, err
+	})
+}
+
+func unmarshalToken(rQuery tm.ResponseQuery) (*api.APIDataResponse, error) {
+	return unmarshalAs(rQuery, "token", func(b []byte) (interface{}, error) {
+		sToken := new(state.Token)
+		err := sToken.UnmarshalBinary(b)
+		rToken := new(response.Token)
+		rToken.Precision = sToken.Precision
+		rToken.URL = sToken.ChainUrl
+		rToken.Symbol = sToken.Symbol
+		rToken.Meta = sToken.Meta
+		return rToken, err
+	})
+}
+
+func unmarshalTokenAccount(rQuery tm.ResponseQuery) (*api.APIDataResponse, error) {
+	return unmarshalAs(rQuery, "tokenAccount", func(b []byte) (interface{}, error) {
+		sAccount := new(state.TokenAccount)
+		err := sAccount.UnmarshalBinary(b)
+		ta := api.NewTokenAccount(sAccount.ChainUrl, sAccount.TokenUrl.String)
+		rAccount := response.NewTokenAccount(ta, sAccount.GetBalance())
+		return rAccount, err
+	})
+}
+
+func unmarshalTokenTx(rQuery tm.ResponseQuery) (*transactions.TokenSend, error) {
+	_, txRaw := common.BytesSlice(rQuery.Value)
+	sTx := new(state.Transaction)
+	err := sTx.UnmarshalBinary(txRaw)
+	if err != nil {
+		return nil, NewAccumulateError(err)
+	}
+
+	tx := new(transactions.TokenSend)
+	_, err = tx.Unmarshal(sTx.Transaction.Bytes())
+	if err != nil {
+		return nil, NewAccumulateError(err)
+	}
+
+	return tx, nil
+}
+
+func (q *Query) unmarshalByType(rQuery tm.ResponseQuery) (*api.APIDataResponse, error) {
+	sChain := new(state.Chain)
+	err := sChain.UnmarshalBinary(rQuery.Value)
+	if err != nil {
+		return nil, fmt.Errorf("invalid state object: %v", err)
+	}
+
+	switch sChain.Type {
+	case types.ChainTypeAdi:
+		return unmarshalADI(rQuery)
+
+	case types.ChainTypeToken:
+		return unmarshalToken(rQuery)
+
+	case types.ChainTypeTokenAccount, types.ChainTypeSignatureGroup:
+		// TODO Is it really OK to unmarshal a sig group as an account? That's
+		// what the orginal `ChainStates` did...
+		return unmarshalTokenAccount(rQuery)
+
+	case types.ChainTypeAnonTokenAccount:
+		adi, _, _ := types.ParseIdentityChainPath(sChain.ChainUrl.AsString())
+		adi += "/dc/ACME"
+		return q.GetTokenAccount(&adi)
+	}
+
+	rAPI := new(api.APIDataResponse)
+	rAPI.Type = types.String(sChain.Type.Name())
+	msg := []byte(fmt.Sprintf("{\"entry\":\"%x\"}", rQuery.Value))
+	rAPI.Data = (*json.RawMessage)(&msg)
+	return rAPI, nil
+}


### PR DESCRIPTION
Factor out unmarshalling from `api.Query.Get*` into separate functions. In `api.Query.GetChainState`, use a switch statement to call the appropriate unmarshaller, instead of issuing a duplicate query.