### PR TITLE
Remove anonymous interface field

### DIFF
--- a/types/state/ADI.go
+++ b/types/state/ADI.go
@@ -20,17 +20,12 @@ const (
 	KeyTypeChain
 )
 
-type adiState struct {
+type AdiState struct {
 	Chain
 
 	KeyType KeyType     `json:"keyType"`
 	KeyData types.Bytes `json:"keyData"`
 	Nonce   uint64      `json:"nonce"`
-}
-
-type AdiState struct {
-	Entry
-	adiState
 }
 
 // NewIdentityState this will eventually be the key groups and potentially just a multi-map of types to chain paths controlled by the identity
@@ -174,14 +169,6 @@ func (is *AdiState) UnmarshalBinary(data []byte) error {
 	}
 
 	return nil
-}
-
-func (is *AdiState) MarshalJSON() ([]byte, error) {
-	return json.Marshal(&is.adiState)
-}
-
-func (is *AdiState) UnmarshalJSON(data []byte) error {
-	return json.Unmarshal(data, &is.adiState)
 }
 
 func (k *KeyType) UnmarshalJSON(b []byte) error {

--- a/types/state/Chain.go
+++ b/types/state/Chain.go
@@ -12,7 +12,6 @@ import (
 //Chain information for the state object.  Each state object will contain a header
 //that will consist of the chain type enumerator
 type Chain struct {
-	Entry
 	Type      types.ChainType `json:"type" form:"type" query:"type" validate:"required"`
 	SigSpecId types.Bytes32   `json:"sigSpecId"` //this is the chain id for the sig spec for the chain
 	ChainUrl  types.String    `json:"url" form:"url" query:"url" validate:"required,alphanum"`

--- a/types/state/Object.go
+++ b/types/state/Object.go
@@ -7,13 +7,6 @@ import (
 	"github.com/AccumulateNetwork/accumulated/types"
 )
 
-type Entry interface {
-	MarshalBinary() ([]byte, error)
-	UnmarshalBinary(data []byte) error
-	GetType() uint64 //return the Chain Type for the entry.
-	GetChainUrl() string
-}
-
 //maybe we should have Chain header then entry, rather than entry containing all the Headers
 type Object struct {
 	ChainHeader Chain       `json:"chainHeader"`

--- a/types/state/Token.go
+++ b/types/state/Token.go
@@ -9,17 +9,12 @@ import (
 	"github.com/AccumulateNetwork/accumulated/types"
 )
 
-type token struct {
+// Token implement the Entry interfaces for a token
+type Token struct {
 	Chain
 	Symbol    types.String     `json:"symbol" form:"symbol" query:"symbol" validate:"required,alphanum"`
 	Precision types.Byte       `json:"precision" form:"precision" query:"precision" validate:"required,min=0,max=18"`
 	Meta      *json.RawMessage `json:"meta,omitempty" form:"meta" query:"meta" validate:"optional"`
-}
-
-// Token implement the Entry interfaces for a token
-type Token struct {
-	Entry
-	token
 }
 
 func NewToken(tokenUrl string) *Token {

--- a/types/state/TokenAccount.go
+++ b/types/state/TokenAccount.go
@@ -8,15 +8,10 @@ import (
 	"github.com/AccumulateNetwork/accumulated/types"
 )
 
-type tokenAccount struct {
+type TokenAccount struct {
 	Chain
 	TokenUrl types.UrlChain `json:"tokenUrl"` //need to know who issued tokens, this can be condensed maybe back to adi chain path
 	Balance  big.Int        `json:"balance"`  //store the balance as a big int.
-}
-
-type TokenAccount struct {
-	Entry
-	tokenAccount
 }
 
 //NewTokenAccount create a new token account.  Requires the identity/chain id's and coinbase if applicable

--- a/types/state/Transaction.go
+++ b/types/state/Transaction.go
@@ -9,13 +9,6 @@ import (
 	"github.com/AccumulateNetwork/accumulated/types/api/transactions"
 )
 
-// transactionHeader is the structure that stores the basic information needed
-type txPendingState struct {
-	Signature        []*transactions.ED25519Sig
-	TransactionState *txState
-	Status           string `json:"status" form:"status" query:"status" validate:"required"`
-}
-
 //transaction object will either be on main chain or combined with the header and placed on pending chain.  If this is
 // part of the transactionPending, the Transaction can be nil which means the transaction contents are on the main chain
 type txState struct {
@@ -54,15 +47,15 @@ func NewTransaction(pending *PendingTransaction) (*Transaction, *PendingTransact
 // i.e. transaction header (signature, rcd, transactionid, chainid)
 // the body of the transaction can also be stored for pending transactions.
 type Transaction struct {
-	Entry
 	Chain
 	txState
 }
 
 type PendingTransaction struct {
-	Entry
 	Chain
-	txPendingState
+	Signature        []*transactions.ED25519Sig
+	TransactionState *txState
+	Status           string `json:"status" form:"status" query:"status" validate:"required"`
 }
 
 func (is *Transaction) TransactionHash() *types.Bytes32 {


### PR DESCRIPTION
A number of types in `types` have an unused anonymous interface field. Because this field is never set, calling any of it's methods will cause a panic. Because the field is never referenced by anything, it should be removed. Because the interface type is never referenced by anything (except these fields), it should be removed.

In addition, a number of types contain an anonymous struct field that does not appear to serve a purpose, in that the fields might as well be included directly. Except for one case where the embedded type was referenced elsewhere, I moved the embedded type's field into the 'parent' type and removed the embedded type. The only side effect this will have is to make the 'parent' type's fields exported.