### PR TITLE
Clarify state loading

### DIFF
--- a/internal/chain/adi.go
+++ b/internal/chain/adi.go
@@ -29,7 +29,7 @@ func (ADI) DeliverTx(st *state.StateEntry, tx *transactions.GenTransaction) (*De
 	if st == nil {
 		return nil, fmt.Errorf("current state not defined")
 	}
-	if st.IdentityState == nil {
+	if st.AdiChain == nil {
 		return nil, fmt.Errorf("missing sponsor identity")
 	}
 	if tx.Signature == nil {
@@ -37,7 +37,7 @@ func (ADI) DeliverTx(st *state.StateEntry, tx *transactions.GenTransaction) (*De
 	}
 
 	adiState := state.AdiState{}
-	err := adiState.UnmarshalBinary(st.IdentityState.Entry)
+	err := adiState.UnmarshalBinary(st.AdiState.Entry)
 	if err != nil {
 		return nil, fmt.Errorf("unable to unmarshal adi state entry, %v", err)
 	}

--- a/internal/chain/anonymous_token.go
+++ b/internal/chain/anonymous_token.go
@@ -75,14 +75,15 @@ func (c *AnonToken) deposit(st *state.StateEntry, tx *transactions.GenTransactio
 
 	//now check if the anonymous chain already exists.
 	//adiStateData := currentState.IdentityState
-	chainState := state.Chain{}
 
 	var txHash types.Bytes32
 	copy(txHash[:], tx.TransactionHash())
 	adiChainId := types.GetChainIdFromChainPath(&adi)
 
 	// if the identity state is nil, then it means we do not have any anon accts setup yet.
-	if st.IdentityState == nil {
+	if st.AdiState == nil {
+		chainState := state.Chain{}
+
 		//we'll just create an adi state and set the initial values, and lock it so it cannot be updated.
 		chainState.SetHeader(types.String(adi), types.ChainTypeAnonTokenAccount)
 		//need to flag this as an anonymous account
@@ -96,11 +97,7 @@ func (c *AnonToken) deposit(st *state.StateEntry, tx *transactions.GenTransactio
 		st.DB.AddStateEntry(adiChainId, &txHash, data)
 
 	} else {
-		err := chainState.UnmarshalBinary(st.IdentityState.Entry)
-		if err != nil {
-			return nil, err
-		}
-		if chainState.Type != types.ChainTypeAnonTokenAccount {
+		if st.AdiHeader.Type != types.ChainTypeAnonTokenAccount {
 			return nil, fmt.Errorf("adi for an anoymous chain is not an anonymous account")
 		}
 	}
@@ -172,7 +169,7 @@ func (c *AnonToken) deposit(st *state.StateEntry, tx *transactions.GenTransactio
 func (v *AnonToken) sendToken(st *state.StateEntry, tx *transactions.GenTransaction) (*DeliverTxResult, error) {
 	res := new(DeliverTxResult)
 
-	if st.IdentityState == nil {
+	if st.AdiState == nil {
 		return nil, fmt.Errorf("identity state does not exist for anonymous account")
 	}
 

--- a/internal/chain/synthetic_identity_create.go
+++ b/internal/chain/synthetic_identity_create.go
@@ -25,7 +25,7 @@ func (SynIdentityCreate) CheckTx(st *state.StateEntry, tx *transactions.GenTrans
 		return fmt.Errorf("current state not defined")
 	}
 
-	if st.IdentityState != nil {
+	if st.AdiState != nil {
 		return fmt.Errorf("identity already exists")
 	}
 
@@ -44,7 +44,7 @@ func (SynIdentityCreate) DeliverTx(st *state.StateEntry, tx *transactions.GenTra
 		return nil, fmt.Errorf("current state not defined")
 	}
 
-	if st.IdentityState != nil {
+	if st.AdiState != nil {
 		return nil, fmt.Errorf("identity already exists")
 	}
 

--- a/internal/chain/synthetic_transaction_deposit.go
+++ b/internal/chain/synthetic_transaction_deposit.go
@@ -84,7 +84,7 @@ func checkSynTxDeposit(st *state.StateEntry, data []byte) (*state.AdiState, *sta
 	}
 
 	ids := state.AdiState{}
-	err = ids.UnmarshalBinary(st.IdentityState.Entry)
+	err = ids.UnmarshalBinary(st.AdiState.Entry)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/internal/chain/token_chain_create.go
+++ b/internal/chain/token_chain_create.go
@@ -27,7 +27,7 @@ func (TokenChainCreate) CheckTx(st *state.StateEntry, tx *transactions.GenTransa
 		return fmt.Errorf("current state not defined")
 	}
 
-	if st.IdentityState == nil {
+	if st.AdiState == nil {
 		return fmt.Errorf("identity not defined")
 	}
 
@@ -48,7 +48,7 @@ func (TokenChainCreate) DeliverTx(st *state.StateEntry, tx *transactions.GenTran
 		return nil, fmt.Errorf("current state not defined")
 	}
 
-	if st.IdentityState == nil {
+	if st.AdiState == nil {
 		return nil, fmt.Errorf("identity not defined")
 	}
 

--- a/internal/chain/token_issuance.go
+++ b/internal/chain/token_issuance.go
@@ -31,7 +31,7 @@ func (TokenIssuance) DeliverTx(st *state.StateEntry, tx *transactions.GenTransac
 		return nil, fmt.Errorf("current State not defined")
 	}
 
-	if st.IdentityState == nil {
+	if st.AdiState == nil {
 		return nil, fmt.Errorf("identity not defined, unable to issue token")
 	}
 
@@ -40,7 +40,7 @@ func (TokenIssuance) DeliverTx(st *state.StateEntry, tx *transactions.GenTransac
 	}
 
 	id := &state.AdiState{}
-	err := id.UnmarshalBinary(st.IdentityState.Entry)
+	err := id.UnmarshalBinary(st.AdiState.Entry)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/chain/token_transaction.go
+++ b/internal/chain/token_transaction.go
@@ -20,7 +20,7 @@ func (TokenTx) instruction() types.TxType  { return types.TxTypeTokenTx }
 func (TokenTx) BeginBlock() {}
 
 func (TokenTx) CheckTx(st *state.StateEntry, tx *transactions.GenTransaction) error {
-	if st.IdentityState == nil {
+	if st.AdiState == nil {
 		return fmt.Errorf("identity state does not exist for anonymous transaction")
 	}
 
@@ -48,13 +48,13 @@ func (TokenTx) DeliverTx(st *state.StateEntry, tx *transactions.GenTransaction) 
 	}
 
 	ids := &state.AdiState{}
-	err = ids.UnmarshalBinary(st.IdentityState.Entry)
+	err = ids.UnmarshalBinary(st.AdiState.Entry)
 	if err != nil {
 		return nil, fmt.Errorf("error unmarshaling adi")
 	}
 
 	tas := &state.TokenAccount{}
-	err = tas.UnmarshalBinary(st.IdentityState.Entry)
+	err = tas.UnmarshalBinary(st.AdiState.Entry)
 	if err != nil {
 		return nil, fmt.Errorf("error unmarshaling token account")
 	}
@@ -151,7 +151,7 @@ func canSendTokens(st *state.StateEntry, tas *state.TokenAccount, withdrawal *tr
 		return fmt.Errorf("no account exists for the chain")
 	}
 
-	if st.IdentityState == nil {
+	if st.AdiState == nil {
 		return fmt.Errorf("no identity exists for the chain")
 	}
 

--- a/types/state/Chain.go
+++ b/types/state/Chain.go
@@ -77,11 +77,25 @@ func (h *Chain) UnmarshalBinary(data []byte) error {
 	return nil
 }
 
-func UnmarshalChain(data []byte) (*Chain, error) {
-	ch := new(Chain)
-	err := ch.UnmarshalBinary(data)
+// LoadChain retrieves and unmarshals the specified chain.
+func (db *StateDB) LoadChain(chainId []byte) (*Object, *Chain, error) {
+	state, err := db.GetCurrentEntry(chainId)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return ch, nil
+
+	chain := new(Chain)
+	err = state.As(chain)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to unmarshal chain: %v", err)
+	}
+
+	return state, chain, nil
+}
+
+// LoadChainADI retrieves and unmarshals the ADI of the chain.
+func (db *StateDB) LoadChainADI(chain *Chain) (*types.Bytes32, *Object, *Chain, error) {
+	adiChain := types.GetIdentityChainFromIdentity(chain.ChainUrl.AsString())
+	adiState, adiHeader, err := db.LoadChain(adiChain.Bytes())
+	return adiChain, adiState, adiHeader, err
 }


### PR DESCRIPTION
- Move state loading from chain.Manager to package state
- Add StateDB.LoadChain, which retrieves and unmarshals a chain
- Add StateDB.LoadChainADI, which retrieves and unmarshals a chain's ADI
- Add StateDB.LoadChainAndADI, which calls both of the above
- Rename StateEntry.IdentityState to AdiState

This also removes some (but not all) redundant state retrieval and unmarshalling.