### PR TITLE
Correctly encode ADI TX type

### DIFF
--- a/types/api/ADI.go
+++ b/types/api/ADI.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"fmt"
+
 	"github.com/AccumulateNetwork/accumulated/smt/common"
 	"github.com/AccumulateNetwork/accumulated/types"
 )
@@ -39,7 +40,7 @@ func (ic *ADI) SetKeyHash(hash *types.Bytes32) {
 
 func (ic *ADI) MarshalBinary() ([]byte, error) {
 	var buffer bytes.Buffer
-	buffer.Write(common.Int64Bytes(int64(types.TxTypeIdentityCreate)))
+	buffer.Write(common.Uint64Bytes(uint64(types.TxTypeIdentityCreate)))
 
 	idn, err := ic.URL.MarshalBinary()
 	if err != nil {
@@ -58,8 +59,8 @@ func (ic *ADI) UnmarshalBinary(data []byte) (err error) {
 			err = fmt.Errorf("insufficent data to unmarshal MultiSigTx %v", err)
 		}
 	}()
-	txType, data := common.BytesInt64(data)
-	if txType != int64(types.TxTypeIdentityCreate) {
+	txType, data := common.BytesUint64(data)
+	if txType != types.TxTypeIdentityCreate.AsUint64() {
 		return fmt.Errorf("unable to unmarshal ADI, expecting identity type")
 	}
 	err = ic.URL.UnmarshalBinary(data)

--- a/types/api/transactions/gentransaction_test.go
+++ b/types/api/transactions/gentransaction_test.go
@@ -1,12 +1,16 @@
-package transactions
+package transactions_test
 
 import (
 	"crypto/ed25519"
 	"crypto/sha256"
+	"encoding"
 	"fmt"
 	"sort"
 	"testing"
 
+	"github.com/AccumulateNetwork/accumulated/types"
+	"github.com/AccumulateNetwork/accumulated/types/api"
+	. "github.com/AccumulateNetwork/accumulated/types/api/transactions"
 	"github.com/stretchr/testify/require"
 )
 
@@ -145,4 +149,25 @@ func TestGenTransaction_UnMarshal(t *testing.T) {
 		_, err := tx.UnMarshal([]byte{})
 		require.Error(t, err)
 	})
+}
+
+func TestGenTransaction_TransactionType(t *testing.T) {
+	cases := map[string]struct {
+		Data encoding.BinaryMarshaler
+		Type types.TxType
+	}{
+		"ADI": {new(api.ADI), types.TxTypeIdentityCreate},
+		// TODO Add all payload types
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			b, err := c.Data.MarshalBinary()
+			require.NoError(t, err)
+
+			tx := new(GenTransaction)
+			tx.Transaction = b
+			require.Equal(t, c.Type.AsUint64(), tx.TransactionType())
+		})
+	}
 }


### PR DESCRIPTION
`api.ADI` encodes its TX type as an `int64`. It needs to be encoded as a `uint64`.