### PR TITLE
Merge create-identity and create-chain

### DIFF
--- a/internal/chain/anonymous_token.go
+++ b/internal/chain/anonymous_token.go
@@ -22,7 +22,7 @@ type tokenAccountTx struct {
 	txHash  []*types.Bytes32
 }
 
-func (*AnonToken) createIdentity() types.TxType { return types.TxTypeSyntheticTokenDeposit }
+func (*AnonToken) createChain() types.TxType { return types.TxTypeSyntheticTokenDeposit }
 
 func (*AnonToken) updateChain() types.ChainType { return types.ChainTypeAnonTokenAccount }
 

--- a/internal/chain/synthetic_identity_create.go
+++ b/internal/chain/synthetic_identity_create.go
@@ -11,7 +11,7 @@ import (
 
 type SynIdentityCreate struct{}
 
-func (SynIdentityCreate) createIdentity() types.TxType {
+func (SynIdentityCreate) createChain() types.TxType {
 	return types.TxTypeSyntheticIdentityCreate
 }
 

--- a/internal/chain/synthetic_transaction_deposit.go
+++ b/internal/chain/synthetic_transaction_deposit.go
@@ -11,7 +11,7 @@ import (
 
 type SynTxDeposit struct{}
 
-func (SynTxDeposit) createIdentity() types.TxType {
+func (SynTxDeposit) createChain() types.TxType {
 	return types.TxTypeSyntheticTokenDeposit
 }
 


### PR DESCRIPTION
`internal/chain.validator` distinguishes between create-identity and create-chain operations. This PR removes that distinction.