### PR TITLE
Allow Relay to use any ABCI RPC client

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -50,11 +50,7 @@ jobs:
         ./accumulated init follower -w .nodes -n EastXeons -l tcp://127.0.2.1:3000
 
     - name: Run follower
-      run: |
-        ./accumulated run -w .nodes/Node0 &
-        PID=$!
-        ( sleep 5; kill -9 $PID; touch .nodes/did-kill ) &
-        wait $PID || [ -e .nodes/did-kill ]
+      run: ./accumulated run -w .nodes/Node0 --ci-stop-after 5s
 
     - name: Init localhost
       run: |

--- a/cmd/accumulated/cmd_loadtest.go
+++ b/cmd/accumulated/cmd_loadtest.go
@@ -14,6 +14,7 @@ import (
 	acctesting "github.com/AccumulateNetwork/accumulated/internal/testing"
 	"github.com/AccumulateNetwork/accumulated/networks"
 	"github.com/spf13/cobra"
+	"github.com/tendermint/tendermint/rpc/client"
 	rpc "github.com/tendermint/tendermint/rpc/client/http"
 )
 
@@ -43,7 +44,7 @@ func init() {
 }
 
 func loadTest(cmd *cobra.Command, args []string) {
-	var clients []*rpc.HTTP
+	var clients []client.ABCIClient
 
 	if flagLoadTest.BatchSize < 1 {
 		if flagLoadTest.TransactionCount > 5 {

--- a/internal/relay/client.go
+++ b/internal/relay/client.go
@@ -1,0 +1,28 @@
+package relay
+
+import (
+	"context"
+
+	"github.com/tendermint/tendermint/rpc/client"
+	"github.com/tendermint/tendermint/rpc/client/http"
+)
+
+type Batchable interface {
+	client.ABCIClient
+	NewBatch() Batch
+}
+
+type Batch interface {
+	client.ABCIClient
+	Send(context.Context) ([]interface{}, error)
+	Count() int
+	Clear() int
+}
+
+type rpcClient struct {
+	*http.HTTP
+}
+
+func (c rpcClient) NewBatch() Batch {
+	return c.HTTP.NewBatch()
+}

--- a/internal/relay/helper.go
+++ b/internal/relay/helper.go
@@ -7,11 +7,12 @@ import (
 
 	"github.com/AccumulateNetwork/accumulated/internal/node"
 	"github.com/AccumulateNetwork/accumulated/networks"
+	"github.com/tendermint/tendermint/rpc/client"
 	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
 )
 
 func NewWith(targetList ...string) (*Relay, error) {
-	rpcClients := []*rpchttp.HTTP{}
+	clients := []client.ABCIClient{}
 	for _, nameOrIP := range targetList {
 		net := networks.Networks[nameOrIP]
 		ip, err := url.Parse(nameOrIP)
@@ -29,8 +30,8 @@ func NewWith(targetList ...string) (*Relay, error) {
 		if err != nil {
 			return nil, err
 		}
-		rpcClients = append(rpcClients, client)
+		clients = append(clients, client)
 	}
-	txBouncer := New(rpcClients...)
+	txBouncer := New(clients...)
 	return txBouncer, nil
 }


### PR DESCRIPTION
Allows `relay.Relay` to accept any `rpc.ABCIClient` instead of restricting it to only `rpc/http.HTTP`. Batching will be transparently ignored for clients other than `rpc/http.HTTP`.