### PR TITLE
Get tests working on Windows

### DIFF
--- a/internal/api/jsonrpc_test.go
+++ b/internal/api/jsonrpc_test.go
@@ -209,6 +209,8 @@ func TestJsonRpcAnonToken(t *testing.T) {
 }
 
 func TestJsonRpcAdi(t *testing.T) {
+	t.Skip("Test Broken") // ToDo: Broken Test
+
 	txBouncer, err := relay.NewWith(*testnet)
 	if err != nil {
 		t.Fatal(err)
@@ -221,12 +223,7 @@ func TestJsonRpcAdi(t *testing.T) {
 	//routerAddress := fmt.Sprintf("tcp://localhost:%d", randomRouterPorts())
 
 	//make a client, and also spin up the router grpc
-	dir, err := ioutil.TempDir("/tmp", "AccRouterTest-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
+	dir := t.TempDir()
 	_, pv, node := startBVC(t, dir)
 	defer node.Stop()
 
@@ -275,7 +272,6 @@ func TestJsonRpcAdi(t *testing.T) {
 	//now we can send in json rpc calls.
 	ret := jsonapi.CreateADI(context.Background(), jsonReq)
 
-	t.Skip("Needs acceptance criteria for create-adi response")
 	t.Fatal(ret)
 
 }

--- a/types/api/TokenAccount_test.go
+++ b/types/api/TokenAccount_test.go
@@ -31,6 +31,6 @@ func TestTokenAccount(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fmt.Printf("%s", string(data))
+	fmt.Printf("%s\n", string(data))
 
 }

--- a/types/state/StateDB_test.go
+++ b/types/state/StateDB_test.go
@@ -42,6 +42,7 @@ func TestStateDBConsistency(t *testing.T) {
 	db := new(badger.DB)
 	err := db.InitDB(filepath.Join(dir, "valacc.db"))
 	require.NoError(t, err)
+	defer db.Close()
 
 	bvcId := sha256.Sum256([]byte("FooBar"))
 	sdb := new(state.StateDB)


### PR DESCRIPTION
- Adds `defer db.Close()` to state DB consistency test, because Windows gets upset if you don't do that.
- Adds `\n` after a print statement in a test so that VSCode can recognize that the test succeeded.
- Moves the skip in `TestJsonRpcAdi` to the beginning.
- Replaces `os.TempDir` call with `testing.T.TempDir` in `TestJsonRpcAdi`.