### PR TITLE
Basic ADI creation

### DIFF
--- a/internal/abci/e2e_statedb_test.go
+++ b/internal/abci/e2e_statedb_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/AccumulateNetwork/accumulated/smt/storage/badger"
 	"github.com/AccumulateNetwork/accumulated/types/state"
 	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/crypto"
 )
 
 func TestStateDBConsistency(t *testing.T) {
@@ -22,8 +23,8 @@ func TestStateDBConsistency(t *testing.T) {
 	sdb := new(state.StateDB)
 	sdb.Load(db, bvcId[:], true)
 
-	app, client := createApp(t, sdb)
-	anonTokenTest(t, app, client, 10)
+	n := createApp(t, sdb, crypto.Address{})
+	n.anonTokenTest(10)
 
 	height := sdb.BlockIndex()
 	rootHash := sdb.RootHash()

--- a/internal/abci/e2e_test.go
+++ b/internal/abci/e2e_test.go
@@ -1,203 +1,133 @@
 package abci_test
 
 import (
-	"crypto/ed25519"
 	"crypto/sha256"
-	"encoding/json"
-	"fmt"
-	"sync"
 	"testing"
 
-	"github.com/AccumulateNetwork/accumulated/internal/abci"
-	accapi "github.com/AccumulateNetwork/accumulated/internal/api"
-	"github.com/AccumulateNetwork/accumulated/internal/chain"
-	"github.com/AccumulateNetwork/accumulated/internal/relay"
 	acctesting "github.com/AccumulateNetwork/accumulated/internal/testing"
-	"github.com/AccumulateNetwork/accumulated/types"
 	anon "github.com/AccumulateNetwork/accumulated/types/anonaddress"
 	"github.com/AccumulateNetwork/accumulated/types/api"
 	"github.com/AccumulateNetwork/accumulated/types/api/transactions"
-	"github.com/AccumulateNetwork/accumulated/types/state"
-	"github.com/AccumulateNetwork/accumulated/types/synthetic"
 	"github.com/stretchr/testify/require"
-	abcitypes "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto"
 	randpkg "golang.org/x/exp/rand"
 )
 
 var rand = randpkg.New(randpkg.NewSource(0))
-var fakeTxid = sha256.Sum256([]byte("fake txid"))
 
 type Tx = transactions.GenTransaction
 
 func TestE2E_Accumulator_AnonToken(t *testing.T) {
-	app, client := createAppWithMemDB(t)
-	originAddr := anonTokenTest(t, app, client, 10)
+	n := createAppWithMemDB(t, crypto.Address{})
+	originAddr := n.anonTokenTest(11)
 
-	t.Log(mustJSON(t, appGetChainState(t, app, originAddr)))
+	t.Log(mustJSON(t, n.GetChainState(originAddr, nil)))
+}
+
+func TestE2E_Accumulator_ADI(t *testing.T) {
+	n := createAppWithMemDB(t, crypto.Address{})
+
+	anonSponsor := generateKey()
+	anonAccount := generateKey()
+	newAdi := generateKey()
+
+	n.Batch(func(send func(*Tx)) {
+		tx, err := acctesting.CreateFakeSyntheticDeposit(anonSponsor, anonAccount)
+		require.NoError(n.t, err)
+		send(tx)
+	})
+
+	wallet := new(transactions.WalletEntry)
+	wallet.Nonce = 1
+	wallet.PrivateKey = anonAccount.Bytes()
+	wallet.Addr = anon.GenerateAcmeAddress(anonAccount.PubKey().Bytes())
+
+	n.Batch(func(send func(*Tx)) {
+		adi := new(api.ADI)
+		adi.URL = "RoadRunner"
+		adi.PublicKeyHash = sha256.Sum256(newAdi.PubKey().Address())
+
+		sponsorUrl := anon.GenerateAcmeAddress(anonAccount.PubKey().Bytes())
+		tx, err := transactions.New(sponsorUrl, func(hash []byte) (*transactions.ED25519Sig, error) {
+			return wallet.Sign(hash), nil
+		}, adi)
+		require.NoError(t, err)
+
+		send(tx)
+	})
+
+	n.client.Wait()
+
+	t.Log(mustJSON(t, n.GetChainState("RoadRunner", nil)))
 }
 
 func BenchmarkE2E_Accumulator_AnonToken(b *testing.B) {
-	_, client := createAppWithMemDB(b)
+	n := createAppWithMemDB(b, crypto.Address{})
 
-	_, sponsor, _ := ed25519.GenerateKey(rand)
-	_, recipient, _ := ed25519.GenerateKey(rand)
+	sponsor := generateKey()
+	recipient := generateKey()
 
-	client.Batch(func(send func(*Tx)) {
-		send(createFakeSyntheticDeposit(b, sponsor, recipient))
-	}, onErr(b))
+	n.Batch(func(send func(*Tx)) {
+		tx, err := acctesting.CreateFakeSyntheticDeposit(sponsor, recipient)
+		require.NoError(b, err)
+		send(tx)
+	})
 
 	origin := transactions.NewWalletEntry()
 	origin.Nonce = 1
-	origin.PrivateKey = recipient
-	origin.Addr = anon.GenerateAcmeAddress(recipient.Public().(ed25519.PublicKey))
+	origin.PrivateKey = recipient.Bytes()
+	origin.Addr = anon.GenerateAcmeAddress(recipient.PubKey().Address())
 
 	rwallet := transactions.NewWalletEntry()
 
 	b.ResetTimer()
-	client.Batch(func(send func(*Tx)) {
+	n.Batch(func(send func(*Tx)) {
 		for i := 0; i < b.N; i++ {
 			output := transactions.Output{Dest: rwallet.Addr, Amount: 1000}
 			exch := transactions.NewTokenSend(origin.Addr, output)
-			tx, err := transactions.New(origin, exch)
+			tx, err := transactions.New(origin.Addr, func(hash []byte) (*transactions.ED25519Sig, error) {
+				return origin.Sign(hash), nil
+			}, exch)
 			require.NoError(b, err)
 			send(tx)
 		}
-	}, onErr(b))
+	})
 }
 
-func createAppWithMemDB(t testing.TB) (abcitypes.Application, *acctesting.ABCIApplicationClient) {
-	appId := sha256.Sum256([]byte("foo bar"))
-	db := new(state.StateDB)
-	err := db.Open("valacc.db", appId[:], true, true)
-	require.NoError(t, err)
+func (n *fakeNode) anonTokenTest(count int) string {
+	sponsor := generateKey()
+	recipient := generateKey()
 
-	return createApp(t, db)
-}
-
-func createApp(t testing.TB, db *state.StateDB) (abcitypes.Application, *acctesting.ABCIApplicationClient) {
-	_, bvcKey, _ := ed25519.GenerateKey(rand)
-
-	appChan := make(chan abcitypes.Application)
-	appClient := acctesting.NewABCIApplicationClient(appChan, nextHeight)
-	defer close(appChan)
-
-	bvc := chain.NewBlockValidator()
-	mgr, err := chain.NewManager(accapi.NewQuery(relay.New(appClient)), db, bvcKey, bvc)
-	require.NoError(t, err)
-
-	app, err := abci.NewAccumulator(db, crypto.Address{}, mgr)
-	require.NoError(t, err)
-	appChan <- app
-
-	return app, appClient
-}
-
-func mustJSON(t testing.TB, v interface{}) string {
-	b, err := json.Marshal(v)
-	require.NoError(t, err)
-	return string(b)
-}
-
-func createFakeSyntheticDeposit(t testing.TB, sponsor, recipient ed25519.PrivateKey) *Tx {
-	t.Helper()
-
-	sponsorAdi := types.String(anon.GenerateAcmeAddress(sponsor.Public().(ed25519.PublicKey)))
-	recipientAdi := types.String(anon.GenerateAcmeAddress(recipient.Public().(ed25519.PublicKey)))
-
-	//create a fake synthetic deposit for faucet.
-	deposit := synthetic.NewTokenTransactionDeposit(fakeTxid[:], &sponsorAdi, &recipientAdi)
-	amtToDeposit := int64(50000)                             //deposit 50k tokens
-	deposit.DepositAmount.SetInt64(amtToDeposit * 100000000) // assume 8 decimal places
-	deposit.TokenUrl = types.String("dc/ACME")
-
-	depData, err := deposit.MarshalBinary()
-	require.NoError(t, err)
-
-	tx := new(Tx)
-	tx.SigInfo = new(transactions.SignatureInfo)
-	tx.Transaction = depData
-	tx.SigInfo.URL = *recipientAdi.AsString()
-	tx.ChainID = types.GetChainIdFromChainPath(recipientAdi.AsString())[:]
-	tx.Routing = types.GetAddressFromIdentity(recipientAdi.AsString())
-
-	ed := new(transactions.ED25519Sig)
-	tx.SigInfo.Nonce = 1
-	ed.PublicKey = recipient.Public().(ed25519.PublicKey)
-	err = ed.Sign(tx.SigInfo.Nonce, recipient, tx.TransactionHash())
-	require.NoError(t, err)
-	tx.Signature = append(tx.Signature, ed)
-	return tx
-}
-
-func appQuery(t testing.TB, app abcitypes.Application, q *api.Query) *api.APIDataResponse {
-	payload, err := q.MarshalBinary()
-	require.NoError(t, err)
-
-	resp := app.Query(abcitypes.RequestQuery{Data: payload})
-	require.Zero(t, resp.Code)
-
-	var msg json.RawMessage = []byte(fmt.Sprintf("{\"entry\":\"%x\"}", resp.Value))
-	chain := new(state.Chain)
-	require.NoError(t, chain.UnmarshalBinary(resp.Value))
-	return &api.APIDataResponse{Type: types.String(chain.Type.Name()), Data: &msg}
-}
-
-func appGetChainState(t testing.TB, app abcitypes.Application, url string) *api.APIDataResponse {
-	q := new(api.Query)
-	q.Url = url
-	q.RouteId = types.GetAddressFromIdentity(&url)
-	q.ChainId = types.GetChainIdFromChainPath(&url).Bytes()
-	return appQuery(t, app, q)
-}
-
-var lastHeight int64
-var heightMu sync.Mutex
-
-func nextHeight() int64 {
-	heightMu.Lock()
-	defer heightMu.Unlock()
-	lastHeight++
-	return lastHeight
-}
-
-func onErr(t testing.TB) func(error) {
-	return func(err error) {
-		t.Helper()
-		require.NoError(t, err)
-	}
-}
-
-func anonTokenTest(t testing.TB, app abcitypes.Application, client *acctesting.ABCIApplicationClient, count int) string {
-	_, sponsor, _ := ed25519.GenerateKey(rand)
-	_, recipient, _ := ed25519.GenerateKey(rand)
-
-	client.Batch(func(send func(*Tx)) {
-		send(createFakeSyntheticDeposit(t, sponsor, recipient))
-	}, onErr(t))
+	n.Batch(func(send func(*Tx)) {
+		tx, err := acctesting.CreateFakeSyntheticDeposit(sponsor, recipient)
+		require.NoError(n.t, err)
+		send(tx)
+	})
 
 	origin := transactions.NewWalletEntry()
 	origin.Nonce = 1
-	origin.PrivateKey = recipient
-	origin.Addr = anon.GenerateAcmeAddress(recipient.Public().(ed25519.PublicKey))
+	origin.PrivateKey = recipient.Bytes()
+	origin.Addr = anon.GenerateAcmeAddress(recipient.PubKey().Bytes())
 
 	recipients := make([]*transactions.WalletEntry, 10)
 	for i := range recipients {
 		recipients[i] = transactions.NewWalletEntry()
 	}
 
-	client.Batch(func(send func(*Tx)) {
+	n.Batch(func(send func(*Tx)) {
 		for i := 0; i < count; i++ {
 			recipient := recipients[rand.Intn(len(recipients))]
 			output := transactions.Output{Dest: recipient.Addr, Amount: 1000}
 			exch := transactions.NewTokenSend(origin.Addr, output)
-			tx, err := transactions.New(origin, exch)
-			require.NoError(t, err)
+			tx, err := transactions.New(origin.Addr, func(hash []byte) (*transactions.ED25519Sig, error) {
+				return origin.Sign(hash), nil
+			}, exch)
+			require.NoError(n.t, err)
 			send(tx)
 		}
-	}, onErr(t))
+	})
 
-	client.Wait()
+	n.client.Wait()
 
 	return origin.Addr
 }

--- a/internal/abci/utils_test.go
+++ b/internal/abci/utils_test.go
@@ -1,0 +1,106 @@
+package abci_test
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/AccumulateNetwork/accumulated/internal/abci"
+	accapi "github.com/AccumulateNetwork/accumulated/internal/api"
+	"github.com/AccumulateNetwork/accumulated/internal/chain"
+	"github.com/AccumulateNetwork/accumulated/internal/relay"
+	acctesting "github.com/AccumulateNetwork/accumulated/internal/testing"
+	"github.com/AccumulateNetwork/accumulated/types"
+	"github.com/AccumulateNetwork/accumulated/types/api"
+	"github.com/AccumulateNetwork/accumulated/types/api/transactions"
+	"github.com/AccumulateNetwork/accumulated/types/state"
+	"github.com/stretchr/testify/require"
+	abcitypes "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/crypto"
+	tmed25519 "github.com/tendermint/tendermint/crypto/ed25519"
+)
+
+func createAppWithMemDB(t testing.TB, addr crypto.Address) *fakeNode {
+	appId := sha256.Sum256([]byte("foo bar"))
+	db := new(state.StateDB)
+	err := db.Open("valacc.db", appId[:], true, true)
+	require.NoError(t, err)
+
+	return createApp(t, db, addr)
+}
+
+func createApp(t testing.TB, db *state.StateDB, addr crypto.Address) *fakeNode {
+	_, bvcKey, _ := ed25519.GenerateKey(rand)
+
+	n := new(fakeNode)
+	n.t = t
+
+	appChan := make(chan abcitypes.Application)
+	defer close(appChan)
+
+	n.client = acctesting.NewABCIApplicationClient(appChan, n.NextHeight, func(err error) {
+		t.Helper()
+		require.NoError(t, err)
+	})
+	n.query = accapi.NewQuery(relay.New(n.client))
+
+	bvc := chain.NewBlockValidator()
+	mgr, err := chain.NewManager(n.query, db, bvcKey, bvc)
+	require.NoError(t, err)
+
+	n.app, err = abci.NewAccumulator(db, addr, mgr)
+	require.NoError(t, err)
+	appChan <- n.app
+
+	return n
+}
+
+func mustJSON(t testing.TB, v interface{}) string {
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(b)
+}
+
+type fakeNode struct {
+	t      testing.TB
+	app    abcitypes.Application
+	client *acctesting.ABCIApplicationClient
+	query  *accapi.Query
+	height int64
+}
+
+func (n *fakeNode) NextHeight() int64 {
+	n.height++
+	return n.height
+}
+
+func (n *fakeNode) Query(q *api.Query) *api.APIDataResponse {
+	payload, err := q.MarshalBinary()
+	require.NoError(n.t, err)
+
+	resp := n.app.Query(abcitypes.RequestQuery{Data: payload})
+	require.Zero(n.t, resp.Code, "Query failed: %s", resp.Info)
+
+	var msg json.RawMessage = []byte(fmt.Sprintf("{\"entry\":\"%x\"}", resp.Value))
+	chain := new(state.Chain)
+	require.NoError(n.t, chain.UnmarshalBinary(resp.Value))
+	return &api.APIDataResponse{Type: types.String(chain.Type.Name()), Data: &msg}
+}
+
+func (n *fakeNode) GetChainState(url string, txid []byte) *api.APIDataResponse {
+	r, err := n.query.GetChainState(&url, txid)
+	require.NoError(n.t, err)
+	return r
+}
+
+func (n *fakeNode) Batch(inBlock func(func(*transactions.GenTransaction))) {
+	n.t.Helper()
+	n.client.Batch(inBlock)
+}
+
+func generateKey() tmed25519.PrivKey {
+	_, key, _ := ed25519.GenerateKey(rand)
+	return tmed25519.PrivKey(key)
+}

--- a/internal/api/jsonrpc_test.go
+++ b/internal/api/jsonrpc_test.go
@@ -255,6 +255,7 @@ func TestJsonRpcAdi(t *testing.T) {
 	adiJson := json.RawMessage(data)
 	req.Tx.Data = &adiJson
 
+	// TODO Why does this sign a ledger? This will fail in GenTransaction.
 	ledger := types.MarshalBinaryLedgerAdiChainPath(*adi.URL.AsString(), *req.Tx.Data, req.Tx.Timestamp)
 	sig, err := kpSponsor.Sign(ledger)
 	if err != nil {

--- a/internal/api/unmarshal.go
+++ b/internal/api/unmarshal.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/AccumulateNetwork/accumulated/types/synthetic"
 
 	"github.com/AccumulateNetwork/accumulated/smt/common"
@@ -43,9 +44,12 @@ func unmarshalAs(rQuery tm.ResponseQuery, typ string, as func([]byte) (interface
 
 func unmarshalADI(rQuery tm.ResponseQuery) (*api.APIDataResponse, error) {
 	return unmarshalAs(rQuery, "adi", func(b []byte) (interface{}, error) {
-		adi := new(response.ADI)
-		err := adi.ADI.UnmarshalBinary(b)
-		return adi, err
+		sAdi := new(state.AdiState)
+		err := sAdi.UnmarshalBinary(b)
+		rAdi := new(response.ADI)
+		rAdi.URL = sAdi.ChainUrl
+		rAdi.PublicKeyHash = sAdi.KeyData.AsBytes32()
+		return rAdi, err
 	})
 }
 

--- a/internal/chain/adi.go
+++ b/internal/chain/adi.go
@@ -34,28 +34,42 @@ func (ADI) DeliverTx(st *state.StateEntry, tx *transactions.GenTransaction) (*De
 		return nil, fmt.Errorf("no signatures available")
 	}
 
-	adiState := state.AdiState{}
-	err := adiState.UnmarshalBinary(st.AdiState.Entry)
-	if err != nil {
-		return nil, fmt.Errorf("unable to unmarshal adi state entry, %v", err)
-	}
+	switch st.AdiHeader.Type {
+	case types.ChainTypeAnonTokenAccount:
+		account := new(state.TokenAccount)
+		err := st.AdiState.As(account)
+		if err != nil {
+			return nil, fmt.Errorf("error unmarshaling anon state account object, %v", err)
+		}
 
-	//this should be done at a higher level...
-	if !adiState.VerifyKey(tx.Signature[0].PublicKey) {
-		return nil, fmt.Errorf("key is not supported by current ADI state")
-	}
+	case types.ChainTypeAdi:
+		adiState := state.AdiState{}
+		err := adiState.UnmarshalBinary(st.AdiState.Entry)
+		if err != nil {
+			return nil, fmt.Errorf("unable to unmarshal adi state entry, %v", err)
+		}
 
-	if !adiState.VerifyAndUpdateNonce(tx.SigInfo.Nonce) {
-		return nil, fmt.Errorf("invalid nonce, adi state %d but provided %d", adiState.Nonce, tx.SigInfo.Nonce)
+		//this should be done at a higher level...
+		if !adiState.VerifyKey(tx.Signature[0].PublicKey) {
+			return nil, fmt.Errorf("key is not supported by current ADI state")
+		}
+
+		if !adiState.VerifyAndUpdateNonce(tx.SigInfo.Nonce) {
+			return nil, fmt.Errorf("invalid nonce, adi state %d but provided %d", adiState.Nonce, tx.SigInfo.Nonce)
+		}
+
+	default:
+		return nil, fmt.Errorf("chain type %d cannot sponsor ADIs", st.AdiHeader.Type)
 	}
 
 	ic := api.ADI{}
-	err = ic.UnmarshalBinary(tx.Transaction)
+	err := ic.UnmarshalBinary(tx.Transaction)
 	if err != nil {
 		return nil, fmt.Errorf("transaction is not a valid identity create message")
 	}
 
-	isc := synthetic.NewAdiStateCreate(tx.TransactionHash(), &adiState.ChainUrl, &ic.URL, &ic.PublicKeyHash)
+	fromUrl := types.String(tx.SigInfo.URL)
+	isc := synthetic.NewAdiStateCreate(tx.TransactionHash(), &fromUrl, &ic.URL, &ic.PublicKeyHash)
 	iscData, err := isc.MarshalBinary()
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal synthetic transaction")

--- a/internal/chain/anonymous_token.go
+++ b/internal/chain/anonymous_token.go
@@ -2,8 +2,9 @@ package chain
 
 import (
 	"fmt"
-	"github.com/AccumulateNetwork/accumulated/types/api"
 	"math/big"
+
+	"github.com/AccumulateNetwork/accumulated/types/api"
 
 	"github.com/AccumulateNetwork/accumulated/types"
 	types2 "github.com/AccumulateNetwork/accumulated/types/anonaddress"
@@ -90,6 +91,7 @@ func (c *AnonToken) deposit(st *state.StateEntry, tx *transactions.GenTransactio
 			return nil, fmt.Errorf("adi for an anoymous chain is not an anonymous account")
 		}
 		//now can unmarshal the account
+		account = new(state.TokenAccount)
 		err := account.UnmarshalBinary(st.AdiState.Entry)
 		if err != nil {
 			return nil, fmt.Errorf("error unmarshaling anon state account object, %v", err)

--- a/internal/chain/validator.go
+++ b/internal/chain/validator.go
@@ -87,19 +87,14 @@ func (v *validator) DeliverTx(st *state.StateEntry, tx *transactions.GenTransact
 		return nil, err
 	}
 
-	// No chain state exists for tx.ChainID
-	if st.ChainHeader == nil {
-		chain := v.chainCreate[txType]
-		if chain == nil {
-			return nil, fmt.Errorf("cannot create identity: unsupported TX type: %d", txType)
-		}
-		return chain.DeliverTx(st, tx)
+	// TODO Remove this hack
+	if st.ChainHeader != nil && st.ChainHeader.Type == types.ChainTypeAnonTokenAccount && txType == types.TxTypeTokenTx {
+		return v.chainUpdate[types.ChainTypeAnonTokenAccount].DeliverTx(st, tx)
 	}
 
-	// Chain and its ADI both exist
-	chain := v.chainUpdate[st.ChainHeader.Type]
+	chain := v.chainCreate[txType]
 	if chain == nil {
-		return nil, fmt.Errorf("cannot update chain: unsupported chain type: %d", st.ChainHeader.Type)
+		return nil, fmt.Errorf("cannot create identity: unsupported TX type: %d", txType)
 	}
 	return chain.DeliverTx(st, tx)
 }

--- a/internal/testing/state.go
+++ b/internal/testing/state.go
@@ -1,0 +1,47 @@
+package testing
+
+import (
+	"crypto/sha256"
+
+	"github.com/AccumulateNetwork/accumulated/types"
+	anon "github.com/AccumulateNetwork/accumulated/types/anonaddress"
+	"github.com/AccumulateNetwork/accumulated/types/api/transactions"
+	"github.com/AccumulateNetwork/accumulated/types/synthetic"
+	ed25519 "github.com/tendermint/tendermint/crypto/ed25519"
+)
+
+func CreateFakeSyntheticDeposit(sponsor, recipient ed25519.PrivKey) (*transactions.GenTransaction, error) {
+	sponsorAdi := types.String(anon.GenerateAcmeAddress(sponsor.PubKey().Bytes()))
+	recipientAdi := types.String(anon.GenerateAcmeAddress(recipient.PubKey().Bytes()))
+
+	//create a fake synthetic deposit for faucet.
+	fakeTxid := sha256.Sum256([]byte("fake txid"))
+	// NewTokenTransactionDeposit(txId types.Bytes, from *types.String, to *types.String)
+	deposit := synthetic.NewTokenTransactionDeposit(fakeTxid[:], &sponsorAdi, &recipientAdi)
+	amtToDeposit := int64(50000)                             //deposit 50k tokens
+	deposit.DepositAmount.SetInt64(amtToDeposit * 100000000) // assume 8 decimal places
+	deposit.TokenUrl = types.String("dc/ACME")
+
+	depData, err := deposit.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+
+	tx := new(transactions.GenTransaction)
+	tx.SigInfo = new(transactions.SignatureInfo)
+	tx.Transaction = depData
+	tx.SigInfo.URL = *recipientAdi.AsString()
+	tx.ChainID = types.GetChainIdFromChainPath(recipientAdi.AsString())[:]
+	tx.Routing = types.GetAddressFromIdentity(recipientAdi.AsString())
+
+	ed := new(transactions.ED25519Sig)
+	tx.SigInfo.Nonce = 1
+	ed.PublicKey = recipient.PubKey().Bytes()
+	err = ed.Sign(tx.SigInfo.Nonce, recipient, tx.TransactionHash())
+	if err != nil {
+		return nil, err
+	}
+
+	tx.Signature = append(tx.Signature, ed)
+	return tx, nil
+}

--- a/types/api/TokenTx.go
+++ b/types/api/TokenTx.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+
 	"github.com/AccumulateNetwork/accumulated/smt/common"
 	"github.com/AccumulateNetwork/accumulated/types"
 )

--- a/types/state/ADI.go
+++ b/types/state/ADI.go
@@ -29,9 +29,9 @@ type AdiState struct {
 }
 
 // NewIdentityState this will eventually be the key groups and potentially just a multi-map of types to chain paths controlled by the identity
-func NewIdentityState(adi string) *AdiState {
+func NewIdentityState(adi types.String) *AdiState {
 	r := &AdiState{}
-	r.SetHeader(types.String(adi), types.ChainTypeAdi)
+	r.SetHeader(adi, types.ChainTypeAdi)
 	return r
 }
 

--- a/types/state/ADI_test.go
+++ b/types/state/ADI_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/AccumulateNetwork/accumulated/types"
 	"github.com/tendermint/tendermint/crypto/ed25519"
 )
 
@@ -19,7 +20,7 @@ func TestIdentityState(t *testing.T) {
 
 	key := ed25519.GenPrivKeyFromSecret(seed[:])
 
-	ids := NewIdentityState(testidentity)
+	ids := NewIdentityState(types.String(testidentity))
 	err = ids.SetKeyData(KeyTypePublic, key.PubKey().Bytes())
 	if err != nil {
 		t.Fatal(err)

--- a/types/state/TokenAccount.go
+++ b/types/state/TokenAccount.go
@@ -3,9 +3,9 @@ package state
 import (
 	"bytes"
 	"fmt"
-	"github.com/AccumulateNetwork/accumulated/smt/common"
 	"math/big"
 
+	"github.com/AccumulateNetwork/accumulated/smt/common"
 	"github.com/AccumulateNetwork/accumulated/types"
 )
 

--- a/types/synthetic/AdiStateCreate.go
+++ b/types/synthetic/AdiStateCreate.go
@@ -52,7 +52,7 @@ func (a *AdiStateCreate) UnmarshalBinary(data []byte) (err error) {
 	if err != nil {
 		return fmt.Errorf("insufficient data to unmarshal Adi State Create message header, %v", err)
 	}
-	i := 1 + a.Header.Size()
+	i := a.Header.Size()
 	if len(data) < i+32 {
 		return fmt.Errorf("insufficient data to unmarshal Adi State Create message key hash")
 	}

--- a/types/synthetic/AdiStateCreate_test.go
+++ b/types/synthetic/AdiStateCreate_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/AccumulateNetwork/accumulated/types"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewAdiStateCreate(t *testing.T) {
@@ -15,17 +16,25 @@ func TestNewAdiStateCreate(t *testing.T) {
 	toAdi := types.String("redwagon")
 
 	txId := types.Bytes32(sha256.Sum256([]byte("sometxid")))
-	adiStateCreate := NewAdiStateCreate(txId[:], &fromAdi, &toAdi, &pubKeyHash)
+	original := NewAdiStateCreate(txId[:], &fromAdi, &toAdi, &pubKeyHash)
 
-	data, err := json.Marshal(adiStateCreate)
-	if err != nil {
-		t.Fatalf("error marshalling adiStateCreate %v", err)
-	}
+	t.Run("JSON", func(t *testing.T) {
+		data, err := json.Marshal(original)
+		require.NoError(t, err, "Marshalling")
 
-	adiStateCreate2 := AdiStateCreate{}
-	err = json.Unmarshal(data, &adiStateCreate2)
-	if err != nil {
-		t.Fatalf("error unmarshalling adiStateCreate %v", err)
-	}
+		unmarshalled := new(AdiStateCreate)
+		err = json.Unmarshal(data, &unmarshalled)
+		require.NoError(t, err, "Unmarshalling")
+		require.Equal(t, original, unmarshalled)
+	})
 
+	t.Run("Binary", func(t *testing.T) {
+		data, err := original.MarshalBinary()
+		require.NoError(t, err, "Marshalling")
+
+		unmarshalled := new(AdiStateCreate)
+		err = unmarshalled.UnmarshalBinary(data)
+		require.NoError(t, err, "Unmarshalling")
+		require.Equal(t, original, unmarshalled)
+	})
 }


### PR DESCRIPTION
- `chain.validator`: Add special case for anonymous tokens, use transaction type for all other transactions
- `chain.ADI`: Allow sponsor to be an anonymous token account
- `chain.SynIdentityCreate`: Unmarshal TX payload as `synthetic.AdiStateCreate` instead of `api.ADI`
- `chain.SynIdentityCreate`: Use `StateDB.AddStateEntry` instead of `DeliverTxResult.AddStateData`
- `chain.SynIdentityCreate`: Store chain as `state.AdiState` instead of `api.ADI`
- `synthetic.AdiStateCreate`: Fix bug in unmarshalling