### PR TITLE
Ac 284 support for transactions hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,8 @@
 # Special build files
 engine/overrideversion.go
 # Executable
-/accumulated
-/cli
+cmd/accumulated/accumulated
+cmd/cli/cli
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o
 *.a

--- a/cmd/accumulated/cmd_loadtest.go
+++ b/cmd/accumulated/cmd_loadtest.go
@@ -114,7 +114,7 @@ func loadTest(cmd *cobra.Command, args []string) {
 	time.Sleep(10000 * time.Millisecond)
 
 	for _, v := range addrList[1:] {
-		resp, err := query.GetChainState(&v, nil)
+		resp, err := query.GetChainStateByUrl(v)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)

--- a/cmd/cli/cmd/tx.go
+++ b/cmd/cli/cmd/tx.go
@@ -74,7 +74,6 @@ func GetTX(hash string) {
 	var hashbytes types.Bytes32
 
 	params := new(acmeapi.TokenTxRequest)
-	params.From = types.UrlChain{types.String("queryUrl")}
 	err := hashbytes.FromString(hash)
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/cli/cmd/tx.go
+++ b/cmd/cli/cmd/tx.go
@@ -25,8 +25,8 @@ var txCmd = &cobra.Command{
 		if len(args) > 0 {
 			switch arg := args[0]; arg {
 			case "get":
-				if len(args) > 2 {
-					GetTX(args[1], args[2])
+				if len(args) > 1 {
+					GetTX(args[1])
 				} else {
 					fmt.Println("Usage:")
 					PrintTXGet()
@@ -55,7 +55,7 @@ func init() {
 }
 
 func PrintTXGet() {
-	fmt.Println("  accumulate tx get [token account] [txid]			Get token tx by token account and txid")
+	fmt.Println("  accumulate tx get [txid]			Get token transaction by txid")
 }
 
 func PrintTXCreate() {
@@ -67,14 +67,14 @@ func PrintTX() {
 	PrintTXCreate()
 }
 
-func GetTX(account string, hash string) {
+func GetTX(hash string) {
 
 	var res interface{}
 	var str []byte
 	var hashbytes types.Bytes32
 
 	params := new(acmeapi.TokenTxRequest)
-	params.From = types.UrlChain{types.String(account)}
+	params.From = types.UrlChain{types.String("queryUrl")}
 	err := hashbytes.FromString(hash)
 	if err != nil {
 		log.Fatal(err)

--- a/internal/abci/utils_test.go
+++ b/internal/abci/utils_test.go
@@ -92,8 +92,20 @@ func (n *fakeNode) Query(q *api.Query) *api.APIDataResponse {
 	return &api.APIDataResponse{Type: types.String(chain.Type.Name()), Data: &msg}
 }
 
-func (n *fakeNode) GetChainState(url string, txid []byte) *api.APIDataResponse {
-	r, err := n.query.GetChainState(&url, txid)
+func (n *fakeNode) GetChainStateByUrl(url string) *api.APIDataResponse {
+	r, err := n.query.GetChainStateByUrl(url)
+	require.NoError(n.t, err)
+	return r
+}
+
+func (n *fakeNode) GetChainStateByTxId(txid []byte) *api.APIDataResponse {
+	r, err := n.query.GetChainStateByTxId(txid)
+	require.NoError(n.t, err)
+	return r
+}
+
+func (n *fakeNode) GetChainStateByChainId(txid []byte) *api.APIDataResponse {
+	r, err := n.query.GetChainStateByChainId(txid)
 	require.NoError(n.t, err)
 	return r
 }
@@ -116,7 +128,7 @@ func edSigner(key tmed25519.PrivKey, nonce uint64) func(hash []byte) (*transacti
 }
 
 func (n *fakeNode) GetChainAs(url string, obj encoding.BinaryUnmarshaler) {
-	r, err := n.query.Query(url, nil)
+	r, err := n.query.QueryByUrl(url)
 	require.NoError(n.t, err)
 
 	if r.Response.Code != 0 {

--- a/internal/api/jsonrpc.go
+++ b/internal/api/jsonrpc.go
@@ -390,7 +390,7 @@ func (api *API) getTokenTx(_ context.Context, params json.RawMessage) interface{
 	}
 
 	// validate only TokenTx.Hash (Assuming the hash is the txid)
-	if err = api.validate.StructPartial(req, "Hash", "From"); err != nil {
+	if err = api.validate.StructPartial(req, "Hash"); err != nil {
 		return NewValidatorError(err)
 	}
 
@@ -401,7 +401,7 @@ func (api *API) getTokenTx(_ context.Context, params json.RawMessage) interface{
 	}
 
 	if resp.Type != "tokenTx" && resp.Type != "syntheticTokenDeposit" {
-		return NewValidatorError(fmt.Errorf("Transaction type is %s and not a token transaction", resp.Type))
+		return NewValidatorError(fmt.Errorf("transaction type is %s and not a token transaction", resp.Type))
 	}
 
 	return resp

--- a/internal/api/jsonrpc.go
+++ b/internal/api/jsonrpc.go
@@ -144,7 +144,7 @@ func (api *API) getData(_ context.Context, params json.RawMessage) interface{} {
 	}
 
 	// Tendermint integration here
-	resp, err := api.query.GetChainState(req.URL.AsString(), nil)
+	resp, err := api.query.GetChainStateByUrl(string(req.URL))
 
 	if err != nil {
 		return NewAccumulateError(err)
@@ -169,7 +169,7 @@ func (api *API) getADI(_ context.Context, params json.RawMessage) interface{} {
 	}
 
 	// Tendermint integration here
-	resp, err := api.query.GetAdi(req.URL.AsString())
+	resp, err := api.query.GetAdi(*req.URL.AsString())
 
 	if err != nil {
 		return NewAccumulateError(err)
@@ -232,7 +232,7 @@ func (api *API) getToken(_ context.Context, params json.RawMessage) interface{} 
 	}
 
 	//query tendermint
-	resp, err := api.query.GetToken(req.URL.AsString())
+	resp, err := api.query.GetToken(*req.URL.AsString())
 
 	if err != nil {
 		return NewAccumulateError(err)
@@ -296,13 +296,12 @@ func (api *API) getTokenAccount(_ context.Context, params json.RawMessage) inter
 	}
 
 	// Tendermint integration here
-	taResp, err := api.query.GetTokenAccount(req.URL.AsString())
+	taResp, err := api.query.GetTokenAccount(*req.URL.AsString())
 	if err != nil {
 		return NewValidatorError(err)
 	}
 
 	return taResp
-
 }
 
 func (api *API) sendTx(req *acmeapi.APIRequestRaw, payload []byte) *acmeapi.APIDataResponse {
@@ -396,7 +395,7 @@ func (api *API) getTokenTx(_ context.Context, params json.RawMessage) interface{
 	}
 
 	// Tendermint's integration here
-	resp, err := api.query.GetTransaction(*req.From.AsString(), req.Hash[:])
+	resp, err := api.query.GetTransaction(req.Hash[:])
 	if err != nil {
 		return NewValidatorError(err)
 	}

--- a/internal/api/jsonrpc_test.go
+++ b/internal/api/jsonrpc_test.go
@@ -52,7 +52,7 @@ func TestLoadOnRemote(t *testing.T) {
 
 	queryTokenUrl := addrList[1]
 
-	resp, err := query.GetChainState(&queryTokenUrl, nil)
+	resp, err := query.GetChainStateByUrl(queryTokenUrl)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,7 +75,7 @@ func TestLoadOnRemote(t *testing.T) {
 	}
 	println(string(theJsonData))
 
-	resp, err = query.GetChainState(&queryTokenUrl, nil)
+	resp, err = query.GetChainStateByUrl(queryTokenUrl)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -86,7 +86,7 @@ func TestLoadOnRemote(t *testing.T) {
 	}
 	fmt.Println(string(output))
 	for _, v := range addrList[1:] {
-		resp, err := query.GetChainState(&v, nil)
+		resp, err := query.GetChainStateByUrl(v)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -125,7 +125,7 @@ func TestJsonRpcAnonToken(t *testing.T) {
 	time.Sleep(10 * time.Second)
 
 	queryTokenUrl := addrList[1]
-	resp, err := query.GetTokenAccount(&queryTokenUrl)
+	resp, err := query.GetTokenAccount(queryTokenUrl)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -137,7 +137,7 @@ func TestJsonRpcAnonToken(t *testing.T) {
 	}
 	fmt.Println(string(output))
 
-	resp2, err := query.GetChainState(&queryTokenUrl, nil)
+	resp2, err := query.GetChainStateByUrl(queryTokenUrl)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -162,7 +162,7 @@ func TestJsonRpcAnonToken(t *testing.T) {
 
 	fmt.Println(theJsonData) //ret.Response.Value)
 	for _, v := range addrList[1:] {
-		resp, err := query.GetChainState(&v, nil)
+		resp, err := query.GetChainStateByUrl(v)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -304,7 +304,7 @@ func TestFaucet(t *testing.T) {
 	time.Sleep(3 * time.Second)
 
 	//readback the result.
-	resp, err := query.GetChainState(req.URL.AsString(), nil)
+	resp, err := query.GetChainStateByUrl(string(req.URL))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -328,11 +328,6 @@ func TestFaucet(t *testing.T) {
 		t.Fatal(err)
 	}
 	fmt.Printf("%s\n", string(output))
-	node.Stop()
-
-	<-node.Quit()
-	node.Wait()
-
 }
 
 func TestJsonRpcAdi(t *testing.T) {

--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -71,7 +71,7 @@ func (q *Query) QueryByChainId(chainId []byte) (ret *ctypes.ResultABCIQuery, err
 // queryAll
 // Will search all networks for the information.  Once found, it will return the results.
 func (q *Query) queryAll(apiQuery *api.Query) (ret *ctypes.ResultABCIQuery, err error) {
-	//TODO: when we get the data servers become a thing, we will query that instead to get the information we need
+	//TODO: when the data servers become a thing, we will query that instead to get the information we need
 	//in the mean time, we will need to ping all the bvc's for the needed info.  not ideal by any means, but it works.
 	var results []chan queryData
 	for i := uint64(0); i < q.txRelay.GetNetworkCount(); i++ {

--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -3,6 +3,8 @@ package api
 import (
 	"fmt"
 
+	"github.com/tendermint/tendermint/libs/bytes"
+
 	"github.com/AccumulateNetwork/accumulated/internal/relay"
 	"github.com/AccumulateNetwork/accumulated/smt/common"
 	"github.com/AccumulateNetwork/accumulated/types"
@@ -14,13 +16,17 @@ import (
 )
 
 type Query struct {
-	txBouncer *relay.Relay
+	txRelay *relay.Relay
 }
 
-func NewQuery(txBouncer *relay.Relay) *Query {
+type queryData struct {
+	ret *ctypes.ResultABCIQuery
+	err error
+}
+
+func NewQuery(txRelay *relay.Relay) *Query {
 	q := Query{}
-	//q.client = abcicli.NewLocalClient(nil, app)
-	q.txBouncer = txBouncer
+	q.txRelay = txRelay
 	return &q
 }
 
@@ -29,30 +35,83 @@ func (q *Query) BroadcastTx(gtx *transactions.GenTransaction) (ti relay.Transact
 	if err != nil {
 		return ti, err
 	}
-	ti = q.txBouncer.BatchTx(gtx.Routing, payload)
+	ti = q.txRelay.BatchTx(gtx.Routing, payload)
 	return ti, nil
 }
 
-func (q *Query) Query(url string, txid []byte) (*ctypes.ResultABCIQuery, error) {
+func (q *Query) QueryByUrl(url string) (*ctypes.ResultABCIQuery, error) {
 	addr := types.GetAddressFromIdentity(&url)
 
 	query := api.Query{}
 	query.Url = url
 	query.RouteId = addr
 	query.ChainId = types.GetChainIdFromChainPath(&url).Bytes()
-	query.Content = txid
 
 	payload, err := query.MarshalBinary()
 	if err != nil {
 		return nil, err
 	}
 
-	return q.txBouncer.Query(payload)
+	return q.txRelay.Query(addr, payload)
+}
+
+func (q *Query) QueryByTxId(txId []byte) (*ctypes.ResultABCIQuery, error) {
+	query := api.Query{}
+	query.Content = txId
+	return q.queryAll(&query)
+}
+
+func (q *Query) QueryByChainId(chainId []byte) (ret *ctypes.ResultABCIQuery, err error) {
+	query := api.Query{}
+	query.ChainId = chainId
+	ret, err = q.queryAll(&query)
+	return ret, err
+}
+
+// queryAll
+// Will search all networks for the information.  Once found, it will return the results.
+func (q *Query) queryAll(apiQuery *api.Query) (ret *ctypes.ResultABCIQuery, err error) {
+	//TODO: when we get the data servers become a thing, we will query that instead to get the information we need
+	//in the mean time, we will need to ping all the bvc's for the needed info.  not ideal by any means, but it works.
+	var results []chan queryData
+	for i := uint64(0); i < q.txRelay.GetNetworkCount(); i++ {
+		results = append(results, make(chan queryData))
+		apiQuery.RouteId = i
+		payload, err := apiQuery.MarshalBinary()
+		if err != nil {
+			return nil, err
+		}
+		go q.query(i, payload, results[i])
+	}
+
+	for i := range results {
+		res := <-results[i]
+		if res.err == nil && res.ret != nil {
+			if res.ret.Response.Code == 0 {
+				ret = res.ret
+				err = res.err
+				//we found a match
+				break
+			}
+		}
+	}
+
+	return ret, err
+}
+
+//query
+//internal query call to a targeted bvc.  populates the channel with the query results
+func (q *Query) query(i uint64, payload bytes.HexBytes, r chan queryData) {
+
+	qd := queryData{}
+	qd.ret, qd.err = q.txRelay.Query(i, payload)
+
+	r <- qd
 }
 
 // BatchSend calls the underlying client's BatchSend method, if it has one
 func (q *Query) BatchSend() chan relay.BatchedStatus {
-	return q.txBouncer.BatchSend()
+	return q.txRelay.BatchSend()
 }
 
 //"GetADI()"
@@ -62,8 +121,8 @@ func (q *Query) BatchSend() chan relay.BatchedStatus {
 //"GetData()" Submit url into, and receive ADI/Token/TokenAccount/TokenTx
 
 // GetAdi get the adi state object. Use this to get the nonce.
-func (q *Query) GetAdi(adi *string) (*acmeApi.APIDataResponse, error) {
-	r, err := q.Query(*adi, nil)
+func (q *Query) GetAdi(adi string) (*acmeApi.APIDataResponse, error) {
+	r, err := q.QueryByUrl(adi)
 	if err != nil {
 		return nil, fmt.Errorf("bvc adi query returned error, %v", err)
 	}
@@ -73,8 +132,8 @@ func (q *Query) GetAdi(adi *string) (*acmeApi.APIDataResponse, error) {
 
 // GetToken
 // retrieve the informatin regarding a token
-func (q *Query) GetToken(tokenUrl *string) (*acmeApi.APIDataResponse, error) {
-	r, err := q.Query(*tokenUrl, nil)
+func (q *Query) GetToken(tokenUrl string) (*acmeApi.APIDataResponse, error) {
+	r, err := q.QueryByUrl(tokenUrl)
 	if err != nil {
 		return nil, fmt.Errorf("bvc token query returned error, %v", err)
 	}
@@ -83,8 +142,8 @@ func (q *Query) GetToken(tokenUrl *string) (*acmeApi.APIDataResponse, error) {
 }
 
 // GetTokenAccount get the token balance for a given url
-func (q *Query) GetTokenAccount(adiChainPath *string) (*acmeApi.APIDataResponse, error) {
-	r, err := q.Query(*adiChainPath, nil)
+func (q *Query) GetTokenAccount(adiChainPath string) (*acmeApi.APIDataResponse, error) {
+	r, err := q.QueryByUrl(adiChainPath)
 	if err != nil {
 		return nil, fmt.Errorf("bvc token account query returned error, %v", err)
 	}
@@ -93,8 +152,8 @@ func (q *Query) GetTokenAccount(adiChainPath *string) (*acmeApi.APIDataResponse,
 }
 
 // GetTransactionReference get the transaction id for a given transaction number
-func (q *Query) GetTransactionReference(adiChainPath *string) (*acmeApi.APIDataResponse, error) {
-	r, err := q.Query(*adiChainPath, nil)
+func (q *Query) GetTransactionReference(adiChainPath string) (*acmeApi.APIDataResponse, error) {
+	r, err := q.QueryByUrl(adiChainPath)
 	if err != nil {
 		return nil, fmt.Errorf("transaction id reference chain query returned error, %v", err)
 	}
@@ -106,9 +165,9 @@ func (q *Query) GetTransactionReference(adiChainPath *string) (*acmeApi.APIDataR
 
 // GetTransaction
 // get the tx from the primary url, if the transaction spawned synthetic tx's then return the synth txid's
-func (q *Query) GetTransaction(url string, txId []byte) (resp *acmeApi.APIDataResponse, err error) {
+func (q *Query) GetTransaction(txId []byte) (resp *acmeApi.APIDataResponse, err error) {
 
-	aResp, err := q.Query(url, txId)
+	aResp, err := q.QueryByTxId(txId)
 	if err != nil {
 		return nil, fmt.Errorf("bvc token tx query returned error, %v", err)
 	}
@@ -148,15 +207,41 @@ func (q *Query) GetTransaction(url string, txId []byte) (resp *acmeApi.APIDataRe
 		return resp, NewAccumulateError(err)
 	}
 
-	return unmarshalTransaction(url, txState.Transaction.Bytes(), txId, txSynthTxIds)
+	return unmarshalTransaction(txState.Transaction.Bytes(), txId, txSynthTxIds)
 }
 
-// GetChainState
-// will return the state object of the chain, which include the chain
+// GetChainStateByUrl
+// will return the state object of the chain given a Url, which include the chain
 // header and the current state data for the chain
-func (q *Query) GetChainState(adiChainPath *string, txId []byte) (*api.APIDataResponse, error) {
+func (q *Query) GetChainStateByUrl(adiChainPath string) (*api.APIDataResponse, error) {
 	//this QuerySync call is only temporary until we get router setup.
-	r, err := q.Query(*adiChainPath, txId)
+	r, err := q.QueryByUrl(adiChainPath)
+	if err != nil {
+		return nil, fmt.Errorf("chain query returned error, %v", err)
+	}
+
+	return q.unmarshalChainState(r.Response)
+}
+
+// GetChainStateByTxId
+// will return the state of a transaction given the TxId, which include the chain
+// header and the current state data for the chain
+func (q *Query) GetChainStateByTxId(txId []byte) (*api.APIDataResponse, error) {
+	//this QuerySync call is only temporary until we get router setup.
+	r, err := q.QueryByTxId(txId)
+	if err != nil {
+		return nil, fmt.Errorf("chain query returned error, %v", err)
+	}
+
+	return q.unmarshalChainState(r.Response)
+}
+
+// GetChainStateByChainId
+// will return the state object of the chain given a chainId, which include the chain
+// header and the current state data for the chain
+func (q *Query) GetChainStateByChainId(chainId []byte) (*api.APIDataResponse, error) {
+	//this QuerySync call is only temporary until we get router setup.
+	r, err := q.QueryByChainId(chainId)
 	if err != nil {
 		return nil, fmt.Errorf("chain query returned error, %v", err)
 	}

--- a/internal/api/unmarshal.go
+++ b/internal/api/unmarshal.go
@@ -85,7 +85,7 @@ func unmarshalTxReference(rQuery tm.ResponseQuery) (*api.APIDataResponse, error)
 	})
 }
 
-func unmarshalTokenTx(url string, txPayload []byte, txId types.Bytes, txSynthTxIds types.Bytes) (*api.APIDataResponse, error) {
+func unmarshalTokenTx(txPayload []byte, txId types.Bytes, txSynthTxIds types.Bytes) (*api.APIDataResponse, error) {
 	tx := api.TokenTx{}
 	err := tx.UnmarshalBinary(txPayload)
 	if err != nil {
@@ -94,12 +94,6 @@ func unmarshalTokenTx(url string, txPayload []byte, txId types.Bytes, txSynthTxI
 	txResp := response.TokenTx{}
 	txResp.From = tx.From.String
 	txResp.TxId = txId
-
-	_, queryPath, err := types.ParseIdentityChainPath(&url)
-	_, txPath, err := types.ParseIdentityChainPath(tx.From.AsString())
-	if queryPath != txPath {
-		return nil, fmt.Errorf("url doesn't match transaction query, expecting %s but received %s", txPath, queryPath)
-	}
 
 	if len(txSynthTxIds)/32 != len(tx.To) {
 		return nil, fmt.Errorf("number of synthetic tx, does not match number of outputs")
@@ -129,7 +123,7 @@ func unmarshalTokenTx(url string, txPayload []byte, txId types.Bytes, txSynthTxI
 }
 
 //unmarshalSynthTokenDeposit will unpack the synthetic token deposit and pack it into the response
-func unmarshalSynthTokenDeposit(url string, txPayload []byte, txId types.Bytes, txSynthTxIds types.Bytes) (*api.APIDataResponse, error) {
+func unmarshalSynthTokenDeposit(txPayload []byte, txId types.Bytes, txSynthTxIds types.Bytes) (*api.APIDataResponse, error) {
 	_ = txId
 	tx := synthetic.TokenTransactionDeposit{}
 	err := tx.UnmarshalBinary(txPayload)
@@ -139,18 +133,6 @@ func unmarshalSynthTokenDeposit(url string, txPayload []byte, txId types.Bytes, 
 
 	if len(txSynthTxIds) != 0 {
 		return nil, fmt.Errorf("there should be no synthetic transaction associated with this transaction")
-	}
-
-	_, queryPath, err := types.ParseIdentityChainPath(&url)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing query url path, %v", err)
-	}
-	_, txPath, err := types.ParseIdentityChainPath(tx.ToUrl.AsString())
-	if err != nil {
-		return nil, fmt.Errorf("error parsing url path associated with transaction, %v", err)
-	}
-	if queryPath != txPath {
-		return nil, fmt.Errorf("url doesn't match transaction query, expecting %s but received %s", txPath, queryPath)
 	}
 
 	data, err := json.Marshal(&tx)
@@ -165,14 +147,14 @@ func unmarshalSynthTokenDeposit(url string, txPayload []byte, txId types.Bytes, 
 }
 
 //unmarshalTransaction will unpack the transaction stored on-chain and marshal it into a response
-func unmarshalTransaction(url string, txPayload []byte, txId []byte, txSynthTxIds []byte) (resp *api.APIDataResponse, err error) {
+func unmarshalTransaction(txPayload []byte, txId []byte, txSynthTxIds []byte) (resp *api.APIDataResponse, err error) {
 
 	txType, _ := common.BytesUint64(txPayload)
 	switch types.TxType(txType) {
 	case types.TxTypeTokenTx:
-		resp, err = unmarshalTokenTx(url, txPayload, txId, txSynthTxIds)
+		resp, err = unmarshalTokenTx(txPayload, txId, txSynthTxIds)
 	case types.TxTypeSyntheticTokenDeposit:
-		resp, err = unmarshalSynthTokenDeposit(url, txPayload, txId, txSynthTxIds)
+		resp, err = unmarshalSynthTokenDeposit(txPayload, txId, txSynthTxIds)
 	default:
 		err = fmt.Errorf("unable to extract transaction info for type %s : %x", types.TxType(txType).Name(), txPayload)
 	}

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -61,6 +61,10 @@ func (r *Relay) GetNetworkId(routing uint64) int {
 	return int(routing % r.numNetworks)
 }
 
+func (r *Relay) GetNetworkCount() uint64 {
+	return r.numNetworks
+}
+
 //BatchTx
 //appends the transaction to the transaction queue and returns the tx hash used to track
 //in tendermint, the index within the queue, and the network the transaction will be submitted on
@@ -173,12 +177,8 @@ func (r *Relay) SendTx(tx tmtypes.Tx) (*ctypes.ResultBroadcastTx, error) {
 
 // Query
 // This function will return the state object from the accumulate network for a given URL.
-func (r *Relay) Query(data bytes.HexBytes) (ret *ctypes.ResultABCIQuery, err error) {
-	_, addr, err := decodeQuery(data)
-	if err != nil {
-		return nil, err
-	}
-	return r.client[r.GetNetworkId(addr)].ABCIQuery(context.Background(), "/abci_query", data)
+func (r *Relay) Query(routing uint64, data bytes.HexBytes) (ret *ctypes.ResultABCIQuery, err error) {
+	return r.client[r.GetNetworkId(routing)].ABCIQuery(context.Background(), "/abci_query", data)
 }
 
 func decodeTX(tx tmtypes.Tx) (*transactions.GenTransaction, error) {

--- a/types/api/TokenTx.go
+++ b/types/api/TokenTx.go
@@ -20,8 +20,7 @@ type TokenTx struct {
 }
 
 type TokenTxRequest struct {
-	Hash types.Bytes32  `json:"hash" form:"hash" query:"hash" validate:"required"`
-	From types.UrlChain `json:"from" form:"from" query:"from" validate:"required"`
+	Hash types.Bytes32 `json:"hash" form:"hash" query:"hash" validate:"required"`
 }
 
 //TokenTxOutput is the structure for the output.  Only handles 64 bit amounts at this time.


### PR DESCRIPTION
- decoupled query by url and txid
- added query by txid (i.e. transaction hash) only
- added query by chainId (currently internal-only)