### PR TITLE
Validate against sponsor's sig group (4/4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# Executable (mac, linux)
+accumulated
+cli
+# unignore directories
+!*/
+
 # Binaries for programs and plugins
 *.exe
 *.exe~
@@ -17,9 +23,7 @@
 
 # Special build files
 engine/overrideversion.go
-# Executable
-cmd/accumulated/accumulated
-cmd/cli/cli
+
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o
 *.a

--- a/cmd/cli/cmd/tx.go
+++ b/cmd/cli/cmd/tx.go
@@ -150,14 +150,13 @@ func CreateTX(sender string, receiver string, amount string) {
 		gtx.SigInfo.URL = sender
 		//Provide a nonce, typically this will be queried from identity sig spec and incremented.
 		//since SigGroups are not yet implemented, we will use the unix timestamp for now.
-		gtx.SigInfo.Nonce = uint64(params.Tx.Timestamp)
+		gtx.SigInfo.Unused2 = uint64(params.Tx.Timestamp)
 		//The following will be defined in the SigSpec Group for which key to use
-		gtx.SigInfo.SigSpecHt = 0
-		gtx.SigInfo.Priority = 0
+		gtx.SigInfo.MSHeight = 0
 		gtx.SigInfo.PriorityIdx = 0
 
 		ed := new(transactions.ED25519Sig)
-		err = ed.Sign(gtx.SigInfo.Nonce, pk, gtx.TransactionHash())
+		err = ed.Sign(gtx.SigInfo.Unused2, pk, gtx.TransactionHash())
 		if err != nil {
 			return api.NewSubmissionError(err)
 		}

--- a/internal/api/jsonrpc.go
+++ b/internal/api/jsonrpc.go
@@ -532,7 +532,7 @@ func (api *API) faucet(_ context.Context, params json.RawMessage) interface{} {
 	gtx := new(transactions.GenTransaction)
 	gtx.SigInfo = new(transactions.SignatureInfo)
 	gtx.SigInfo.URL = *destAccount.AsString()
-	gtx.SigInfo.Nonce = wallet.Nonce
+	gtx.SigInfo.Unused2 = wallet.Nonce
 	gtx.Transaction = depData
 	if err := gtx.SetRoutingChainID(); err != nil {
 		return jsonrpc2.NewError(-32802, fmt.Sprintf("bad url generated %s: ", destAccount), err)

--- a/internal/api/jsonrpc_test.go
+++ b/internal/api/jsonrpc_test.go
@@ -22,8 +22,6 @@ import (
 	"github.com/AccumulateNetwork/accumulated/types"
 	"github.com/AccumulateNetwork/accumulated/types/api"
 	"github.com/AccumulateNetwork/accumulated/types/api/response"
-	"github.com/stretchr/testify/require"
-	"github.com/tendermint/tendermint/rpc/client/http"
 )
 
 var testnet = flag.String("testnet", "Localhost", "TestNet to load test")
@@ -113,13 +111,7 @@ func TestJsonRpcAnonToken(t *testing.T) {
 
 	//make a client, and also spin up the router grpc
 	dir := t.TempDir()
-	node, pv := startBVC(t, dir)
-	defer node.Stop()
-
-	rpcClient, err := http.New(node.Config.RPC.ListenAddress)
-	require.NoError(t, err)
-	txBouncer := relay.New(rpcClient)
-	query := NewQuery(txBouncer)
+	_, pv, query := startBVC(t, dir)
 
 	//create a key from the Tendermint node's private key. He will be the defacto source for the anon token.
 	kpSponsor := ed25519.NewKeyFromSeed(pv.Key.PrivKey.Bytes()[:32])
@@ -229,21 +221,7 @@ func TestFaucet(t *testing.T) {
 
 	//make a client, and also spin up the router grpc
 	dir := t.TempDir()
-	node, pv := startBVC(t, dir)
-	_ = pv
-	defer func() {
-		node.Stop()
-		<-node.Quit()
-	}()
-
-	rpcAddr := node.Config.RPC.ListenAddress
-	rpcClient, err := http.New(rpcAddr)
-	if err != nil {
-		t.Fatal(err)
-	}
-	require.NoError(t, err)
-	txBouncer := relay.New(rpcClient)
-	query := NewQuery(txBouncer)
+	_, _, query := startBVC(t, dir)
 
 	//create a key from the Tendermint node's private key. He will be the defacto source for the anon token.
 	_, kpSponsor, _ := ed25519.GenerateKey(nil)
@@ -272,7 +250,7 @@ func TestFaucet(t *testing.T) {
 	gtx.Transaction = tx1
 	gtx.Signature[0].Sign(54321, kpSponsor, gtx.TransactionHash())
 	//changing the nonce will invalidate the signature.
-	gtx.SigInfo.Nonce = 1234
+	gtx.SigInfo.Unused2 = 1234
 
 	//intentionally send in a bogus transaction
 	ti1, _ := query.BroadcastTx(&gtx, nil)
@@ -354,15 +332,10 @@ func TestJsonRpcAdi(t *testing.T) {
 
 	//make a client, and also spin up the router grpc
 	dir := t.TempDir()
-	node, pv := startBVC(t, dir)
-	defer node.Stop()
+	_, pv, query := startBVC(t, dir)
 
 	//kpSponsor := types.CreateKeyPair()
 
-	rpcClient, err := http.New(node.Config.RPC.ListenAddress)
-	require.NoError(t, err)
-	txBouncer := relay.New(rpcClient)
-	query := NewQuery(txBouncer)
 	jsonapi := NewTest(t, query)
 
 	//StartAPI(randomRouterPorts(), client)

--- a/internal/chain/assign_sig_spec_group.go
+++ b/internal/chain/assign_sig_spec_group.go
@@ -43,7 +43,7 @@ func checkAssignSigSpecGroup(st *state.StateEntry, tx *transactions.GenTransacti
 	ssg := new(protocol.SigSpecGroup)
 	_, err = st.DB.LoadChainAs(ssgUrl.ResourceChain(), ssg)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to load key group: %v", err)
+		return nil, nil, fmt.Errorf("failed to load sig spec group: %v", err)
 	}
 
 	var chain state.Chain
@@ -53,7 +53,7 @@ func checkAssignSigSpecGroup(st *state.StateEntry, tx *transactions.GenTransacti
 	case types.ChainTypeTokenAccount:
 		chain = new(state.TokenAccount)
 	default:
-		return nil, nil, fmt.Errorf("cannot assign key group to %v", st.ChainHeader.Type)
+		return nil, nil, fmt.Errorf("cannot assign sig spec group to %v", st.ChainHeader.Type)
 	}
 
 	err = st.ChainState.As(chain)

--- a/internal/chain/create_sig_spec_group.go
+++ b/internal/chain/create_sig_spec_group.go
@@ -36,7 +36,7 @@ func checkCreateSigSpecGroup(st *state.StateEntry, tx *transactions.GenTransacti
 	}
 
 	if len(body.SigSpecs) == 0 {
-		return nil, nil, fmt.Errorf("cannot create empty key group")
+		return nil, nil, fmt.Errorf("cannot create empty sig spec group")
 	}
 
 	sgUrl, err := url.Parse(body.Url)

--- a/internal/chain/identity_create.go
+++ b/internal/chain/identity_create.go
@@ -75,8 +75,8 @@ func (IdentityCreate) DeliverTx(st *state.StateEntry, tx *transactions.GenTransa
 			return nil, fmt.Errorf("key is not supported by current ADI state")
 		}
 
-		if !adi.VerifyAndUpdateNonce(tx.SigInfo.Nonce) {
-			return nil, fmt.Errorf("invalid nonce, adi state %d but provided %d", adi.Nonce, tx.SigInfo.Nonce)
+		if !adi.VerifyAndUpdateNonce(tx.SigInfo.Unused2) {
+			return nil, fmt.Errorf("invalid nonce, adi state %d but provided %d", adi.Nonce, tx.SigInfo.Unused2)
 		}
 	}
 

--- a/internal/testing/load.go
+++ b/internal/testing/load.go
@@ -157,9 +157,9 @@ func BuildTestSynthDepositGenTx(origin *ed25519.PrivateKey) (types.String, *ed25
 	gtx.Routing = types.GetAddressFromIdentity(destAddress.AsString())
 
 	ed := new(transactions.ED25519Sig)
-	gtx.SigInfo.Nonce = 1
+	gtx.SigInfo.Unused2 = 1
 	ed.PublicKey = privateKey[32:]
-	err = ed.Sign(gtx.SigInfo.Nonce, privateKey, gtx.TransactionHash())
+	err = ed.Sign(gtx.SigInfo.Unused2, privateKey, gtx.TransactionHash())
 	if err != nil {
 		return "", nil, nil, fmt.Errorf("failed to sign TX: %v", err)
 	}
@@ -191,9 +191,9 @@ func BuildTestTokenTxGenTx(origin *ed25519.PrivateKey, destAddr string, amount u
 	gtx.Routing = types.GetAddressFromIdentity(from.AsString())
 
 	ed := new(transactions.ED25519Sig)
-	gtx.SigInfo.Nonce = 1
+	gtx.SigInfo.Unused2 = 1
 	ed.PublicKey = (*origin)[32:]
-	err = ed.Sign(gtx.SigInfo.Nonce, *origin, gtx.TransactionHash())
+	err = ed.Sign(gtx.SigInfo.Unused2, *origin, gtx.TransactionHash())
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign TX: %v", err)
 	}

--- a/internal/url/url.go
+++ b/internal/url/url.go
@@ -129,6 +129,13 @@ func ensurePath(s string) string {
 	return "/" + s
 }
 
+// Identity returns a copy of the URL with an empty path.
+func (u *URL) Identity() *URL {
+	v := *u
+	v.Path = ""
+	return &v
+}
+
 // IdentityChain constructs a chain identifier from the lower case hostname. The
 // port is not included.
 //

--- a/protocol/hash_algorithm.go
+++ b/protocol/hash_algorithm.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -28,50 +29,66 @@ func HashAlgorithmByName(s string) HashAlgorithm {
 	}
 }
 
-func (ka HashAlgorithm) String() string {
-	switch ka {
+func (ha HashAlgorithm) String() string {
+	switch ha {
 	case SHA256:
 		return "SHA256"
 	case SHA256D:
 		return "SHA256D"
 	default:
-		return fmt.Sprintf("HashAlgorithm:%d", ka)
+		return fmt.Sprintf("HashAlgorithm:%d", ha)
 	}
 }
 
-func (ka HashAlgorithm) BinarySize() int {
+func (ha HashAlgorithm) Apply(b []byte) ([]byte, error) {
+	switch ha {
+	case Unhashed:
+		return b, nil
+	case SHA256:
+		kh := sha256.Sum256(b)
+		return kh[:], nil
+	case SHA256D:
+		kh := sha256.Sum256(b)
+		kh = sha256.Sum256(kh[:])
+		return kh[:], nil
+	default:
+		return nil, fmt.Errorf("invalid hash algorithm")
+	}
+}
+
+func (ha HashAlgorithm) BinarySize() int {
 	return 1
 }
 
-func (ka HashAlgorithm) MarshalBinary() ([]byte, error) {
-	return []byte{byte(ka)}, nil
+func (ha HashAlgorithm) MarshalBinary() ([]byte, error) {
+	return []byte{byte(ha)}, nil
 }
 
-func (ka *HashAlgorithm) UnmarshalBinary(b []byte) error {
+func (ha *HashAlgorithm) UnmarshalBinary(b []byte) error {
 	if len(b) == 0 {
 		return ErrNotEnoughData
 	}
-	*ka = HashAlgorithm(b[0])
+	*ha = HashAlgorithm(b[0])
 	return nil
 }
 
-func (ka HashAlgorithm) MarshalJSON() ([]byte, error) {
-	return json.Marshal(ka.String())
+func (ha HashAlgorithm) MarshalJSON() ([]byte, error) {
+	return json.Marshal(ha.String())
 }
 
-func (ka *HashAlgorithm) UnmarshalJSON(b []byte) error {
+func (ha *HashAlgorithm) UnmarshalJSON(b []byte) error {
 	var s *string
 	err := json.Unmarshal(b, &s)
 	if err != nil {
 		return nil
 	}
 	if s == nil {
-		*ka = Unhashed
+		*ha = Unhashed
 		return nil
 	}
 
-	*ka = HashAlgorithmByName(*s)
-	if *ka == UnknownHashAlgorithm {
+	*ha = HashAlgorithmByName(*s)
+	if *ha == UnknownHashAlgorithm {
 		return fmt.Errorf("invalid Hash algorithm: %q", *s)
 	}
 	return nil

--- a/protocol/keys.go
+++ b/protocol/keys.go
@@ -1,0 +1,25 @@
+package protocol
+
+import (
+	"bytes"
+	"fmt"
+)
+
+func (ks *SigSpec) FindKey(pubKey []byte, ka KeyAlgorithm) (*KeySpec, error) {
+	for _, key := range ks.Keys {
+		if key.KeyAlgorithm != ka {
+			continue
+		}
+
+		sigKH, err := key.HashAlgorithm.Apply(pubKey)
+		if err != nil {
+			return nil, fmt.Errorf("key spec: %v", err)
+		}
+
+		if bytes.Equal(key.PublicKey, sigKH) {
+			return key, nil
+		}
+	}
+
+	return nil, nil
+}

--- a/types/TransactionTypes.go
+++ b/types/TransactionTypes.go
@@ -35,6 +35,8 @@ const (
 	TxTypeStateStore //
 	TxTypeDataStore  //Data Store can only be sent and thus authorized by an authority node
 	TxTypeAdminVote
+
+	txTypeSyntheticBase = TxTypeSyntheticIdentityCreate
 )
 
 // Enum value map for TxType.
@@ -147,3 +149,5 @@ func (t TxType) AsUint64() uint64 {
 }
 
 func (t TxType) String() string { return t.Name() }
+
+func (t TxType) IsSynthetic() bool { return t >= txTypeSyntheticBase }

--- a/types/api/APIRequests.go
+++ b/types/api/APIRequests.go
@@ -53,14 +53,13 @@ func NewAPIRequest(sig *types.Bytes64, signer *Signer, nonce uint64, data []byte
 	gtx.Transaction = data
 
 	gtx.SigInfo = new(transactions.SignatureInfo)
-	gtx.SigInfo.Nonce = nonce
+	gtx.SigInfo.Unused2 = nonce
 	gtx.SigInfo.URL = *signer.URL.AsString()
-	gtx.SigInfo.SigSpecHt = 0
-	gtx.SigInfo.Priority = 0
+	gtx.SigInfo.MSHeight = 0
 	gtx.SigInfo.PriorityIdx = 0
 
 	ed := new(transactions.ED25519Sig)
-	ed.Nonce = gtx.SigInfo.Nonce
+	ed.Nonce = gtx.SigInfo.Unused2
 	ed.PublicKey = signer.PublicKey[:]
 	ed.Signature = sig.Bytes()
 

--- a/types/api/transactions/SignatureInfo.go
+++ b/types/api/transactions/SignatureInfo.go
@@ -39,10 +39,10 @@ type SignatureInfo struct {
 	// the main chain.  But the only thing that varies from one transaction
 	// to another is the transaction itself.
 	URL         string // URL for the transaction
-	SigSpecHt   uint64 // Height of the SigSpec Chain
-	Priority    uint64 // Priority for the signature in the SigSpec
+	MSHeight    uint64 // Height of the multi sig spec
 	PriorityIdx uint64 // Index within the Priority of the signature used
-	Nonce       uint64 // Nonce for the signature to prevent replays
+	Unused1     uint64 // This field is not used
+	Unused2     uint64 // This field is not used
 }
 
 // Equal
@@ -51,9 +51,9 @@ type SignatureInfo struct {
 // and test that the information in the SignatureInfo is preserved
 func (t *SignatureInfo) Equal(t2 *SignatureInfo) bool {
 	return t.URL == t2.URL && //               URL equal?
-		t.Nonce == t2.Nonce && //              Nonce equal?
-		t.SigSpecHt == t2.SigSpecHt && //      SigSpecHt equal?
-		t.Priority == t2.Priority && //        Priority equal?
+		t.Unused2 == t2.Unused2 && //              Nonce equal?
+		t.MSHeight == t2.MSHeight && //      SigSpecHt equal?
+		t.Unused1 == t2.Unused1 && //        Priority equal?
 		t.PriorityIdx == t2.PriorityIdx //     PriorityIdx equal?  If any fails, this returns false
 }
 
@@ -67,9 +67,9 @@ func (t *SignatureInfo) Marshal() (data []byte, err error) { //            Seria
 	}()
 
 	data = common.SliceBytes([]byte(t.URL))                   //           URL =>
-	data = append(data, common.Uint64Bytes(t.Nonce)...)       //           Nonce =>
-	data = append(data, common.Uint64Bytes(t.SigSpecHt)...)   //           SigSpecHt =>
-	data = append(data, common.Uint64Bytes(t.Priority)...)    //           Priority =>
+	data = append(data, common.Uint64Bytes(t.Unused2)...)     //           Nonce =>
+	data = append(data, common.Uint64Bytes(t.MSHeight)...)    //           SigSpecHt =>
+	data = append(data, common.Uint64Bytes(t.Unused1)...)     //           Priority =>
 	data = append(data, common.Uint64Bytes(t.PriorityIdx)...) //           PriorityIdx =>
 	return data, nil                                          //           All good, return data and nil error
 }
@@ -86,9 +86,9 @@ func (t *SignatureInfo) UnMarshal(data []byte) (nextData []byte, err error) { //
 
 	URL, data := common.BytesSlice(data)           //                      => URL
 	t.URL = string(URL)                            //                       (url must be a string)
-	t.Nonce, data = common.BytesUint64(data)       //                      => Nonce
-	t.SigSpecHt, data = common.BytesUint64(data)   //                      => SigSpecHt
-	t.Priority, data = common.BytesUint64(data)    //                      => Priority
+	t.Unused2, data = common.BytesUint64(data)     //                      => Nonce
+	t.MSHeight, data = common.BytesUint64(data)    //                      => SigSpecHt
+	t.Unused1, data = common.BytesUint64(data)     //                      => Priority
 	t.PriorityIdx, data = common.BytesUint64(data) //                      => PriorityIdx
 	return data, nil                               //
 } //

--- a/types/api/transactions/gentransaction_test.go
+++ b/types/api/transactions/gentransaction_test.go
@@ -32,7 +32,7 @@ func TestTokenTransaction(t *testing.T) {
 	trans := new(GenTransaction)
 	trans.SigInfo = new(SignatureInfo)
 	trans.SigInfo.URL = testurl
-	trans.SigInfo.Nonce = nonce
+	trans.SigInfo.Unused2 = nonce
 	if err := trans.SetRoutingChainID(); err != nil {
 		t.Fatal("could not create the Routing value")
 	}

--- a/types/state/Transaction_test.go
+++ b/types/state/Transaction_test.go
@@ -17,13 +17,10 @@ func TestTransactionState(t *testing.T) {
 	nts1.From = types.UrlChain{"RedWagon/myAccount"}
 	nts1.AddToAccount("BlueWagon/account", uint64(100*100000000))
 
-	var nonce uint64 = 1
-
 	we := accapi.NewWalletEntry()
 	trans := new(transactions.GenTransaction)
 	trans.SigInfo = new(transactions.SignatureInfo)
 	trans.SigInfo.URL = we.Addr
-	trans.SigInfo.Nonce = nonce
 	if err := trans.SetRoutingChainID(); err != nil {
 		t.Fatal("could not create the Routing value")
 	}


### PR DESCRIPTION
Validate transaction signatures against the transaction sponsor's sig group, for all transactions.