### PR TITLE
Run as a service

### DIFF
--- a/cmd/accumulated/cmd_config.go
+++ b/cmd/accumulated/cmd_config.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -27,10 +26,7 @@ func init() {
 
 func setSentryDsn(cmd *cobra.Command, args []string) {
 	entries, err := os.ReadDir(flagMain.WorkDir)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: reading %q: %v\n", flagMain.WorkDir, err)
-		os.Exit(1)
-	}
+	checkf(err, "reading %q", flagMain.WorkDir)
 
 	for _, e := range entries {
 		if !e.IsDir() {
@@ -38,16 +34,10 @@ func setSentryDsn(cmd *cobra.Command, args []string) {
 		}
 
 		cfg, err := config.Load(filepath.Join(flagMain.WorkDir, e.Name()))
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: loading config for %q: %v\n", e.Name(), err)
-			os.Exit(1)
-		}
+		checkf(err, "loading config for %q", e.Name())
 
 		cfg.Accumulate.SentryDSN = args[0]
 		err = config.Store(cfg)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: saving config for %q: %v\n", e.Name(), err)
-			os.Exit(1)
-		}
+		checkf(err, "saving config for %q", e.Name())
 	}
 }

--- a/cmd/accumulated/cmd_run.go
+++ b/cmd/accumulated/cmd_run.go
@@ -1,29 +1,10 @@
 package main
 
 import (
-	"bytes"
-	"crypto/sha256"
-	"encoding/json"
-	"fmt"
-	"io"
-	"log"
-	"net/http"
-	"os"
-	"path/filepath"
 	"time"
 
-	"github.com/AccumulateNetwork/accumulated"
-	"github.com/AccumulateNetwork/accumulated/config"
-	"github.com/AccumulateNetwork/accumulated/internal/abci"
-	"github.com/AccumulateNetwork/accumulated/internal/api"
-	"github.com/AccumulateNetwork/accumulated/internal/chain"
-	"github.com/AccumulateNetwork/accumulated/internal/node"
-	"github.com/AccumulateNetwork/accumulated/internal/relay"
-	"github.com/AccumulateNetwork/accumulated/types/state"
-	"github.com/getsentry/sentry-go"
+	"github.com/kardianos/service"
 	"github.com/spf13/cobra"
-	"github.com/tendermint/tendermint/privval"
-	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
 )
 
 var cmdRun = &cobra.Command{
@@ -37,166 +18,31 @@ var flagRun = struct {
 	CiStopAfter time.Duration
 }{}
 
-//note: making FlagRunStruct an anonymous struct will cause go fmt to fail on Windows
-//var flagRun flagRunStruct
-
 func init() {
 	cmdMain.AddCommand(cmdRun)
 
-	cmdRun.Flags().IntVarP(&flagRun.Node, "node", "n", -1, "Which node are we? [0, n)")
-	cmdRun.Flags().DurationVar(&flagRun.CiStopAfter, "ci-stop-after", 0, "FOR CI ONLY - stop the node after some time")
-	cmdRun.Flag("ci-stop-after").Hidden = true
+	initRunFlags(cmdRun, false)
+}
+
+func initRunFlags(cmd *cobra.Command, forService bool) {
+	cmd.Flags().IntVarP(&flagRun.Node, "node", "n", -1, "Which node are we? [0, n)")
+
+	if !forService {
+		cmd.Flags().DurationVar(&flagRun.CiStopAfter, "ci-stop-after", 0, "FOR CI ONLY - stop the node after some time")
+		cmd.Flag("ci-stop-after").Hidden = true
+	}
 }
 
 func runNode(cmd *cobra.Command, args []string) {
-	workDir := flagMain.WorkDir
-	if cmd.Flag("node").Changed {
-		nodeDir := fmt.Sprintf("Node%d", flagRun.Node)
-		workDir = filepath.Join(workDir, nodeDir)
-	} else if !cmd.Flag("work-dir").Changed {
-		fmt.Fprint(os.Stderr, "Error: at least one of --work-dir or --node is required\n")
-		_ = cmd.Usage()
-		os.Exit(1)
-	}
+	prog := NewProgram(cmd)
+	svc, err := service.New(prog, serviceConfig)
+	check(err)
 
-	config, err := config.Load(workDir)
+	logger, err := svc.Logger(nil)
+	check(err)
+
+	err = svc.Run()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: reading config file: %v\n", err)
-		os.Exit(1)
+		_ = logger.Error(err)
 	}
-
-	if config.Accumulate.SentryDSN != "" {
-		opts := sentry.ClientOptions{
-			Dsn:           config.Accumulate.SentryDSN,
-			Environment:   "Accumulate",
-			HTTPTransport: sentryHack{},
-			Debug:         true,
-		}
-		if accumulated.IsVersionKnown() {
-			opts.Release = accumulated.Commit
-		}
-		err = sentry.Init(opts)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: configuring sentry: %v\n", err)
-			os.Exit(1)
-		}
-		defer sentry.Flush(2 * time.Second)
-	}
-
-	dbPath := filepath.Join(config.RootDir, "valacc.db")
-	bvcId := sha256.Sum256([]byte(config.Instrumentation.Namespace))
-	db := new(state.StateDB)
-	err = db.Open(dbPath, bvcId[:], false, true)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: failed to open database %s: %v", dbPath, err)
-		os.Exit(1)
-	}
-
-	// read private validator
-	pv, err := privval.LoadFilePV(
-		config.PrivValidator.KeyFile(),
-		config.PrivValidator.StateFile(),
-	)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: failed to load private validator: %v", err)
-		os.Exit(1)
-	}
-
-	rpcClient, err := rpchttp.New(config.RPC.ListenAddress)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: failed to reate RPC client: %v", err)
-		os.Exit(1)
-	}
-
-	query := api.NewQuery(relay.New(rpcClient))
-	mgr, err := chain.NewBlockValidator(query, db, pv.Key.PrivKey.Bytes())
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: failed to initialize chain manager: %v", err)
-		os.Exit(1)
-	}
-
-	app, err := abci.NewAccumulator(db, pv.Key.PubKey.Address(), mgr)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: failed to initialize ACBI app: %v", err)
-		os.Exit(1)
-	}
-
-	// Create node
-	node, err := node.New(config, app)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: failed to initialize node: %v\n", err)
-		os.Exit(1)
-	}
-
-	// Start node
-	err = node.Start()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: failed to start node: %v\n", err)
-		os.Exit(1)
-	}
-
-	txRelay, err := relay.NewWith(config.Accumulate.Networks...)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
-	}
-
-	// The query object connects to the BVC, will be replaced with network client router
-	query = api.NewQuery(txRelay)
-
-	api.StartAPI(&config.Accumulate.API, query)
-
-	if flagRun.CiStopAfter == 0 {
-		// Block forever
-		select {}
-	}
-
-	time.Sleep(flagRun.CiStopAfter)
-
-	// TODO I tried stopping the node, but node.Stop() won't return for a
-	// follower node until it's caught up (I think).
-}
-
-type sentryHack struct{}
-
-func (sentryHack) RoundTrip(req *http.Request) (*http.Response, error) {
-	if req.URL.Host != "gitlab.com" {
-		return http.DefaultTransport.RoundTrip(req)
-	}
-
-	defer func() {
-		r := recover()
-		if r != nil {
-			log.Printf("Failed to send event to sentry: %v", r)
-		}
-	}()
-
-	defer req.Body.Close()
-	b, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	var v map[string]interface{}
-	err = json.Unmarshal(b, &v)
-	if err != nil {
-		return nil, err
-	}
-
-	ex := v["exception"]
-
-	// GitLab expects the event to have a different shape
-	v["exception"] = map[string]interface{}{
-		"values": ex,
-	}
-
-	b, err = json.Marshal(v)
-	if err != nil {
-		return nil, err
-	}
-
-	req.ContentLength = int64(len(b))
-	req.Body = io.NopCloser(bytes.NewReader(b))
-	resp, err := http.DefaultTransport.RoundTrip(req)
-	return resp, err
 }

--- a/cmd/accumulated/cmd_service.go
+++ b/cmd/accumulated/cmd_service.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/kardianos/service"
+	"github.com/spf13/cobra"
+)
+
+const (
+	ServiceInstall   = "install"
+	ServiceReinstall = "reinstall"
+	ServiceUninstall = "uninstall"
+	ServiceStart     = "start"
+	ServiceStop      = "stop"
+)
+
+var serviceConfig = &service.Config{
+	Name:        "accumulated",
+	DisplayName: "Accumulated",
+	Description: cmdMain.Short,
+	Arguments:   []string{"run"},
+}
+
+var cmdService = &cobra.Command{
+	Use:       "service [[un|re]install|start|stop]",
+	ValidArgs: []string{ServiceInstall, ServiceReinstall, ServiceUninstall, ServiceStart, ServiceStop},
+	Args:      composeArgs(cobra.OnlyValidArgs, cobra.MaximumNArgs(1)),
+	Run:       manageService,
+}
+
+var flagService = struct {
+	UserService bool
+}{}
+
+func init() {
+	cmdMain.AddCommand(cmdService)
+
+	initRunFlags(cmdService, true)
+	cmdService.Flags().StringVar(&serviceConfig.UserName, "service-user", "", "Service user name")
+	cmdService.Flags().BoolVar(&flagService.UserService, "user-service", false, "Install as a user service instead of a system service")
+}
+
+func manageService(cmd *cobra.Command, args []string) {
+	if len(args) > 1 {
+		printUsageAndExit1(cmd, args)
+	}
+
+	if flagService.UserService {
+		serviceConfig.Option["UserService"] = true
+	}
+
+	prog := NewProgram(cmd)
+	svc, err := service.New(prog, serviceConfig)
+	check(err)
+
+	if len(args) == 0 {
+		st, err := svc.Status()
+		if errors.Is(err, service.ErrNotInstalled) {
+			fmt.Printf("Accumulated service is not installed\n")
+			return
+		}
+		check(err)
+
+		switch st {
+		case service.StatusRunning:
+			fmt.Printf("Accumulated service is running\n")
+		case service.StatusStopped:
+			fmt.Printf("Accumulated service is stopped\n")
+		default:
+			fmt.Printf("Accumulated service status is unknown\n")
+		}
+	}
+
+	switch args[0] {
+	case ServiceInstall, ServiceReinstall:
+		wd, err := prog.workDir()
+		check(err)
+
+		// TODO Better way of doing this?
+		serviceConfig.Arguments = append(serviceConfig.Arguments, "--work-dir", wd)
+	}
+
+	switch args[0] {
+	case ServiceInstall:
+		check(svc.Install())
+	case ServiceReinstall:
+		check(svc.Uninstall())
+		check(svc.Install())
+	case ServiceUninstall:
+		check(svc.Uninstall())
+	case ServiceStart:
+		check(svc.Start())
+	case ServiceStop:
+		check(svc.Stop())
+	default:
+		printUsageAndExit1(cmd, args)
+	}
+}

--- a/cmd/accumulated/cmd_testnet.go
+++ b/cmd/accumulated/cmd_testnet.go
@@ -38,19 +38,16 @@ func initTestNet(cmd *cobra.Command, args []string) {
 	baseIP := net.ParseIP(flagTestNet.BaseIP)
 	if baseIP == nil {
 		fmt.Fprintf(os.Stderr, "Error: %q is not a valid IP address\n", flagTestNet.BaseIP)
-		cmd.Usage()
-		os.Exit(1)
+		printUsageAndExit1(cmd, args)
 	}
 	if baseIP[15] == 0 {
 		fmt.Fprintf(os.Stderr, "Error: base IP address must not end with .0\n")
-		cmd.Usage()
-		os.Exit(1)
+		printUsageAndExit1(cmd, args)
 	}
 
 	if !cmd.Flag("work-dir").Changed {
 		fmt.Fprint(os.Stderr, "Error: --work-dir is required\n")
-		_ = cmd.Usage()
-		os.Exit(1)
+		printUsageAndExit1(cmd, args)
 	}
 
 	n := flagTestNet.NumValidators + flagTestNet.NumFollowers
@@ -76,7 +73,7 @@ func initTestNet(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	err := node.Init(node.InitOptions{
+	check(node.Init(node.InitOptions{
 		WorkDir:   flagMain.WorkDir,
 		ShardName: "LocalhostTestNet",
 		ChainID:   "LocalhostTestNet",
@@ -84,9 +81,5 @@ func initTestNet(cmd *cobra.Command, args []string) {
 		Config:    config,
 		RemoteIP:  IPs,
 		ListenIP:  IPs,
-	})
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
-	}
+	}))
 }

--- a/cmd/accumulated/program.go
+++ b/cmd/accumulated/program.go
@@ -1,0 +1,267 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/AccumulateNetwork/accumulated"
+	"github.com/AccumulateNetwork/accumulated/config"
+	"github.com/AccumulateNetwork/accumulated/internal/abci"
+	"github.com/AccumulateNetwork/accumulated/internal/api"
+	"github.com/AccumulateNetwork/accumulated/internal/chain"
+	"github.com/AccumulateNetwork/accumulated/internal/node"
+	"github.com/AccumulateNetwork/accumulated/internal/relay"
+	"github.com/AccumulateNetwork/accumulated/types/state"
+	"github.com/getsentry/sentry-go"
+	"github.com/kardianos/service"
+	"github.com/rs/zerolog"
+	"github.com/spf13/cobra"
+	"github.com/tendermint/tendermint/libs/log"
+	"github.com/tendermint/tendermint/privval"
+	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
+)
+
+type Program struct {
+	cmd   *cobra.Command
+	db    *state.StateDB
+	node  *node.Node
+	relay *relay.Relay
+	api   *api.API
+}
+
+func NewProgram(cmd *cobra.Command) *Program {
+	p := new(Program)
+	p.cmd = cmd
+	return p
+}
+
+func (p *Program) workDir() (string, error) {
+	if p.cmd.Flag("node").Changed {
+		nodeDir := fmt.Sprintf("Node%d", flagRun.Node)
+		return filepath.Join(flagMain.WorkDir, nodeDir), nil
+	}
+
+	if p.cmd.Flag("work-dir").Changed {
+		return flagMain.WorkDir, nil
+	}
+
+	if service.Interactive() {
+		fmt.Fprint(os.Stderr, "Error: at least one of --work-dir or --node is required\n")
+		printUsageAndExit1(p.cmd, []string{})
+		return "", nil // Not reached
+	} else {
+		return "", fmt.Errorf("at least one of --work-dir or --node is required")
+	}
+}
+
+func (p *Program) Start(s service.Service) error {
+	workDir, err := p.workDir()
+	if err != nil {
+		return err
+	}
+
+	config, err := config.Load(workDir)
+	if err != nil {
+		return fmt.Errorf("reading config file: %v", err)
+	}
+
+	if config.Accumulate.SentryDSN != "" {
+		opts := sentry.ClientOptions{
+			Dsn:           config.Accumulate.SentryDSN,
+			Environment:   "Accumulate",
+			HTTPTransport: sentryHack{},
+			Debug:         true,
+		}
+		if accumulated.IsVersionKnown() {
+			opts.Release = accumulated.Commit
+		}
+		err = sentry.Init(opts)
+		if err != nil {
+			return fmt.Errorf("configuring sentry: %v", err)
+		}
+		defer sentry.Flush(2 * time.Second)
+	}
+
+	dbPath := filepath.Join(config.RootDir, "valacc.db")
+	bvcId := sha256.Sum256([]byte(config.Instrumentation.Namespace))
+	p.db = new(state.StateDB)
+	err = p.db.Open(dbPath, bvcId[:], false, true)
+	if err != nil {
+		return fmt.Errorf("failed to open database %s: %v", dbPath, err)
+	}
+
+	// read private validator
+	pv, err := privval.LoadFilePV(
+		config.PrivValidator.KeyFile(),
+		config.PrivValidator.StateFile(),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to load private validator: %v", err)
+	}
+
+	rpcClient, err := rpchttp.New(config.RPC.ListenAddress)
+	if err != nil {
+		return fmt.Errorf("failed to reate RPC client: %v", err)
+	}
+
+	query := api.NewQuery(relay.New(rpcClient))
+	mgr, err := chain.NewBlockValidator(query, p.db, pv.Key.PrivKey.Bytes())
+	if err != nil {
+		return fmt.Errorf("failed to initialize chain manager: %v", err)
+	}
+
+	var logger log.Logger
+	if service.Interactive() {
+		logger, err = log.NewDefaultLogger(config.LogFormat, config.LogLevel, false)
+	} else {
+		logger, err = newDefaultLogger(s, config.LogFormat, config.LogLevel, false)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: failed to initialize logger: %v", err)
+		os.Exit(1)
+	}
+
+	app, err := abci.NewAccumulator(p.db, pv.Key.PubKey.Address(), mgr, logger)
+	if err != nil {
+		return fmt.Errorf("failed to initialize ACBI app: %v", err)
+	}
+
+	// Create node
+	p.node, err = node.New(config, app, logger)
+	if err != nil {
+		return fmt.Errorf("failed to initialize node: %v", err)
+	}
+
+	// Start node
+	// TODO Feed Tendermint logger to service logger
+	err = p.node.Start()
+	if err != nil {
+		return fmt.Errorf("failed to start node: %v", err)
+	}
+
+	p.relay, err = relay.NewWith(config.Accumulate.Networks...)
+	if err != nil {
+		return fmt.Errorf("failed to start relay: %v", err)
+	}
+
+	query = api.NewQuery(p.relay)
+	p.api, err = api.StartAPI(&config.Accumulate.API, query)
+	if err != nil {
+		return fmt.Errorf("failed to start API: %v", err)
+	}
+	return nil
+}
+
+func (p *Program) Stop(service.Service) error {
+	var errs []error
+	errs = append(errs, p.node.Stop())
+	// TODO stop relay
+	// TODO stop API
+	errs = append(errs, p.db.GetDB().Close())
+
+	for _, err := range errs {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type sentryHack struct{}
+
+func (sentryHack) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL.Host != "gitlab.com" {
+		return http.DefaultTransport.RoundTrip(req)
+	}
+
+	defer func() {
+		r := recover()
+		if r != nil {
+			fmt.Printf("Failed to send event to sentry: %v", r)
+		}
+	}()
+
+	defer req.Body.Close()
+	b, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var v map[string]interface{}
+	err = json.Unmarshal(b, &v)
+	if err != nil {
+		return nil, err
+	}
+
+	ex := v["exception"]
+
+	// GitLab expects the event to have a different shape
+	v["exception"] = map[string]interface{}{
+		"values": ex,
+	}
+
+	b, err = json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+
+	req.ContentLength = int64(len(b))
+	req.Body = io.NopCloser(bytes.NewReader(b))
+	resp, err := http.DefaultTransport.RoundTrip(req)
+	return resp, err
+}
+
+type serviceLogger struct {
+	service.Logger
+	w   *zerolog.ConsoleWriter
+	buf *bytes.Buffer
+	mu  *sync.Mutex
+}
+
+func newServiceLogger(sl service.Logger, cw *zerolog.ConsoleWriter) *serviceLogger {
+	l := new(serviceLogger)
+	l.Logger = sl
+	if cw != nil {
+		l.w = cw
+		l.buf = new(bytes.Buffer)
+		l.w.Out = l.buf
+		l.mu = new(sync.Mutex)
+	}
+	return l
+}
+
+var _ zerolog.LevelWriter = (*serviceLogger)(nil)
+
+func (l *serviceLogger) Write(b []byte) (int, error) {
+	return l.WriteLevel(zerolog.NoLevel, b)
+}
+
+func (l *serviceLogger) WriteLevel(level zerolog.Level, b []byte) (int, error) {
+	// Use zerolog's console writer to format the log message
+	if l.w != nil {
+		l.mu.Lock()
+		l.buf.Reset()
+		_, _ = l.w.Write(b)
+		b = make([]byte, l.buf.Len())
+		copy(b, l.buf.Bytes())
+		l.mu.Unlock()
+	}
+
+	switch level {
+	case zerolog.PanicLevel, zerolog.FatalLevel, zerolog.ErrorLevel:
+		_ = l.Error(string(b))
+	case zerolog.WarnLevel:
+		_ = l.Warning(string(b))
+	default:
+		_ = l.Info(string(b))
+	}
+	return len(b), nil
+}

--- a/cmd/accumulated/tendermint_logger.go
+++ b/cmd/accumulated/tendermint_logger.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/kardianos/service"
+	"github.com/rs/zerolog"
+	"github.com/tendermint/tendermint/libs/log"
+)
+
+// This is based off of Tendermint's NewDefaultLogger
+
+func newDefaultLogger(svc service.Service, format, level string, trace bool) (log.Logger, error) {
+	var writer *zerolog.ConsoleWriter
+	switch strings.ToLower(format) {
+	case log.LogFormatPlain, log.LogFormatText:
+		writer = &zerolog.ConsoleWriter{
+			NoColor:    true,
+			TimeFormat: time.RFC3339,
+			FormatLevel: func(i interface{}) string {
+				if ll, ok := i.(string); ok {
+					return strings.ToUpper(ll)
+				}
+				return "????"
+			},
+		}
+
+	case log.LogFormatJSON:
+
+	default:
+		return nil, fmt.Errorf("unsupported log format: %s", format)
+	}
+
+	logLevel, err := zerolog.ParseLevel(level)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse log level: %v", err)
+	}
+
+	svcLogger, err := svc.Logger(nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get service logger: %v", err)
+	}
+
+	sl := newServiceLogger(svcLogger, writer)
+	zl := zerolog.New(sl).Level(logLevel).With().Timestamp().Logger()
+	return defaultLogger{zl, trace}, nil
+}
+
+// Everything below is ripped from Tendermint
+
+type defaultLogger struct {
+	zerolog.Logger
+
+	trace bool
+}
+
+func (l defaultLogger) Info(msg string, keyVals ...interface{}) {
+	l.Logger.Info().Fields(getLogFields(keyVals...)).Msg(msg)
+}
+
+func (l defaultLogger) Error(msg string, keyVals ...interface{}) {
+	e := l.Logger.Error()
+	if l.trace {
+		e = e.Stack()
+	}
+
+	e.Fields(getLogFields(keyVals...)).Msg(msg)
+}
+
+func (l defaultLogger) Debug(msg string, keyVals ...interface{}) {
+	l.Logger.Debug().Fields(getLogFields(keyVals...)).Msg(msg)
+}
+
+func (l defaultLogger) With(keyVals ...interface{}) log.Logger {
+	return defaultLogger{
+		Logger: l.Logger.With().Fields(getLogFields(keyVals...)).Logger(),
+		trace:  l.trace,
+	}
+}
+
+func getLogFields(keyVals ...interface{}) map[string]interface{} {
+	if len(keyVals)%2 != 0 {
+		return nil
+	}
+
+	fields := make(map[string]interface{}, len(keyVals))
+	for i := 0; i < len(keyVals); i += 2 {
+		fields[fmt.Sprint(keyVals[i])] = keyVals[i+1]
+	}
+
+	return fields
+}

--- a/go.mod
+++ b/go.mod
@@ -20,10 +20,12 @@ require (
 	github.com/golang/mock v1.5.0
 	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/gorilla/mux v1.8.0
+	github.com/kardianos/service v1.2.0
 	github.com/mitchellh/mapstructure v1.4.2
 	github.com/pelletier/go-toml v1.9.4
 	github.com/prometheus/common v0.30.0 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
+	github.com/rs/zerolog v1.24.0
 	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.8.1
@@ -35,7 +37,7 @@ require (
 	golang.org/x/exp v0.0.0-20200331195152-e8c3332aa8e5
 	golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d // indirect
 	golang.org/x/sys v0.0.0-20210917161153-d61c044b1678 // indirect
-	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
+	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	golang.org/x/text v0.3.7 // indirect
 	gopkg.in/ini.v1 v1.63.2 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b

--- a/go.sum
+++ b/go.sum
@@ -542,6 +542,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/julz/importas v0.0.0-20210419104244-841f0c0fe66d/go.mod h1:oSFU2R4XK/P7kNBrnL/FEQlDGN1/6WoxXEjSSXO0DV0=
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
+github.com/kardianos/service v1.2.0 h1:bGuZ/epo3vrt8IPC7mnKQolqFeYJb7Cs8Rk4PSOBB/g=
+github.com/kardianos/service v1.2.0/go.mod h1:CIMRFEJVL+0DS1a3Nx06NaMn4Dz63Ng6O7dl0qH0zVM=
 github.com/kataras/golog v0.0.10/go.mod h1:yJ8YKCmyL+nWjERB90Qwn+bdyBZsaQwU3bTVFgkFIp8=
 github.com/kataras/iris/v12 v12.1.8/go.mod h1:LMYy4VlP67TQ3Zgriz8RE2h2kMZV2SgMYbq3UhfoFmE=
 github.com/kataras/neffos v0.0.14/go.mod h1:8lqADm8PnbeFfL7CLXh1WHw53dG27MC3pgi2R1rmoTE=
@@ -1180,6 +1182,7 @@ golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200814200057-3d37ad5750ed/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210104204734-6f8348627aad/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1201,8 +1204,9 @@ golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210917161153-d61c044b1678 h1:J27LZFQBFoihqXoegpscI10HpjZ7B5WQLLKL2FZXQKw=
 golang.org/x/sys v0.0.0-20210917161153-d61c044b1678/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
-golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/abci/accumulator_test.go
+++ b/internal/abci/accumulator_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	tmabci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto"
+	"github.com/tendermint/tendermint/libs/log"
 )
 
 func TestAccumulator(t *testing.T) {
@@ -58,7 +59,7 @@ func (s *AccumulatorTestSuite) TestCheckTx() {
 	s.Run("Passes valid TX to chain", func() {
 		//build a valid transaction
 		_, origin, _ := ed25519.GenerateKey(nil)
-		destAddress, destPrivKey, tx, err := testing2.BuildTestSynthDepositGenTx(&origin)
+		destAddress, destPrivKey, tx, err := testing2.BuildTestSynthDepositGenTx(origin)
 		_ = destAddress
 		_ = destPrivKey
 
@@ -107,7 +108,7 @@ func (s *AccumulatorTestSuite) TestDeliverTx() {
 	s.Run("Passes valid TX to chain", func() {
 		//build a valid transaction
 		_, origin, _ := ed25519.GenerateKey(nil)
-		destAddress, destPrivKey, tx, err := testing2.BuildTestSynthDepositGenTx(&origin)
+		destAddress, destPrivKey, tx, err := testing2.BuildTestSynthDepositGenTx(origin)
 		_ = destAddress
 		_ = destPrivKey
 
@@ -194,7 +195,7 @@ func (s *AccumulatorTestSuite) App(addr crypto.Address) *abci.Accumulator {
 		addr = crypto.Address{}
 	}
 
-	app, err := abci.NewAccumulator(s.State(), addr, s.Chain())
+	app, err := abci.NewAccumulator(s.State(), addr, s.Chain(), log.MustNewDefaultLogger("plain", "error", false))
 	s.Require().NoError(err)
 	return app
 }

--- a/internal/abci/utils_test.go
+++ b/internal/abci/utils_test.go
@@ -22,6 +22,7 @@ import (
 	abcitypes "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto"
 	tmed25519 "github.com/tendermint/tendermint/crypto/ed25519"
+	"github.com/tendermint/tendermint/libs/log"
 )
 
 func createAppWithMemDB(t testing.TB, addr crypto.Address) *fakeNode {
@@ -52,7 +53,7 @@ func createApp(t testing.TB, db *state.StateDB, addr crypto.Address) *fakeNode {
 	mgr, err := chain.NewBlockValidator(n.query, db, bvcKey)
 	require.NoError(t, err)
 
-	n.app, err = abci.NewAccumulator(db, addr, mgr)
+	n.app, err = abci.NewAccumulator(db, addr, mgr, log.MustNewDefaultLogger("plain", "error", false))
 	require.NoError(t, err)
 	appChan <- n.app
 

--- a/internal/api/jsonrpc_test.go
+++ b/internal/api/jsonrpc_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/AccumulateNetwork/accumulated/types/api/transactions"
+	"github.com/stretchr/testify/require"
 
 	anon "github.com/AccumulateNetwork/accumulated/types/anonaddress"
 
@@ -42,10 +43,14 @@ func TestLoadOnRemote(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	err = txBouncer.Start()
+	require.NoError(t, err)
+	defer func() { require.NoError(t, txBouncer.Stop()) }()
+
 	query := NewQuery(txBouncer)
 	_, privateKeySponsor, _ := ed25519.GenerateKey(nil)
 
-	addrList, err := acctesting.RunLoadTest(query, &privateKeySponsor, *loadWalletCount, *loadTxCount)
+	addrList, err := acctesting.RunLoadTest(query, privateKeySponsor, *loadWalletCount, *loadTxCount)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,7 +121,7 @@ func TestJsonRpcAnonToken(t *testing.T) {
 	//create a key from the Tendermint node's private key. He will be the defacto source for the anon token.
 	kpSponsor := ed25519.NewKeyFromSeed(pv.Key.PrivKey.Bytes()[:32])
 
-	addrList, err := acctesting.RunLoadTest(query, &kpSponsor, *loadWalletCount, *loadTxCount)
+	addrList, err := acctesting.RunLoadTest(query, kpSponsor, *loadWalletCount, *loadTxCount)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -127,7 +127,7 @@ func (q *Query) query(i uint64, payload bytes.HexBytes, r chan queryData) {
 }
 
 // BatchSend calls the underlying client's BatchSend method, if it has one
-func (q *Query) BatchSend() chan relay.BatchedStatus {
+func (q *Query) BatchSend() <-chan relay.BatchedStatus {
 	return q.txRelay.BatchSend()
 }
 

--- a/internal/chain/synthetic_token_deposit_test.go
+++ b/internal/chain/synthetic_token_deposit_test.go
@@ -20,7 +20,7 @@ func TestSynthTokenDeposit_Anon(t *testing.T) {
 
 	_, privKey, _ := ed25519.GenerateKey(nil)
 
-	_, _, gtx, err := testing2.BuildTestSynthDepositGenTx(&privKey)
+	_, _, gtx, err := testing2.BuildTestSynthDepositGenTx(privKey)
 	require.NoError(t, err)
 
 	db := new(state.StateDB)

--- a/internal/node/init.go
+++ b/internal/node/init.go
@@ -58,7 +58,6 @@ func Init(opts InitOptions) (err error) {
 		nodeDir := path.Join(opts.WorkDir, nodeDirName)
 		config.SetRoot(nodeDir)
 
-		config.LogLevel = "error"
 		config.ProxyApp = ""
 		config.P2P.ListenAddress = fmt.Sprintf("%s:%d", opts.ListenIP[i], opts.Port+tmP2pPortOffset)
 		config.RPC.ListenAddress = fmt.Sprintf("%s:%d", opts.ListenIP[i], opts.Port+TmRpcPortOffset)

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -35,18 +35,12 @@ type Node struct {
 }
 
 // New initializes a Tendermint node for the given ABCI application.
-func New(config *config.Config, app abci.Application) (*Node, error) {
+func New(config *config.Config, app abci.Application, logger log.Logger) (*Node, error) {
 	node := new(Node)
 	node.Config = config
 
-	// create logger
-	var err error
-	logger, err := log.NewDefaultLogger(config.LogFormat, config.LogLevel, false)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse log level: %w", err)
-	}
-
 	// create node
+	var err error
 	node.Service, err = nm.New(&config.Config, logger, proxy.NewLocalClientCreator(app), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new Tendermint node: %w", err)

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -197,7 +197,7 @@ func (r *Relay) BatchTx(routing uint64, tx tmtypes.Tx) (ti TransactionInfo) {
 // BatchSend
 // This will dispatch all the transactions that have been put into batches. The calling function does not have to
 // wait for batch to be sent.  This is a fire and forget operation
-func (r *Relay) BatchSend() chan BatchedStatus {
+func (r *Relay) BatchSend() <-chan BatchedStatus {
 	var sendTxsAsBatch []txBatch
 	var sendTxsAsSingle []txBatch
 	//sort out the requests
@@ -224,6 +224,7 @@ func (r *Relay) BatchSend() chan BatchedStatus {
 // dispatch
 // This function is executed as a go routine to send out all the batches
 func dispatch(client []Client, sendAsBatch []txBatch, sendAsSingle []txBatch, stat chan BatchedStatus) {
+	defer close(stat)
 
 	batchedStatus := make(chan BatchedStatus)
 	singlesStatus := make(chan BatchedStatus)
@@ -241,6 +242,7 @@ func dispatch(client []Client, sendAsBatch []txBatch, sendAsSingle []txBatch, st
 }
 
 func dispatchBatch(client []Client, sendBatches []txBatch, status chan BatchedStatus) {
+	defer close(status)
 
 	bs := BatchedStatus{}
 	bs.Status = make([]DispatchStatus, len(sendBatches))
@@ -265,6 +267,7 @@ func dispatchBatch(client []Client, sendBatches []txBatch, status chan BatchedSt
 }
 
 func dispatchSingles(client []Client, sendSingles []txBatch, status chan BatchedStatus) {
+	defer close(status)
 
 	bs := BatchedStatus{}
 	bs.Status = make([]DispatchStatus, len(sendSingles))

--- a/internal/testing/load.go
+++ b/internal/testing/load.go
@@ -8,8 +8,6 @@ import (
 	"sync"
 	"time"
 
-	coregrpc "github.com/tendermint/tendermint/rpc/grpc"
-
 	"github.com/AccumulateNetwork/accumulated/internal/api"
 	"github.com/AccumulateNetwork/accumulated/protocol"
 	"github.com/AccumulateNetwork/accumulated/types"
@@ -18,6 +16,7 @@ import (
 	"github.com/AccumulateNetwork/accumulated/types/api/transactions"
 	"github.com/AccumulateNetwork/accumulated/types/synthetic"
 	abci "github.com/tendermint/tendermint/abci/types"
+	coregrpc "github.com/tendermint/tendermint/rpc/grpc"
 )
 
 // Load
@@ -126,7 +125,7 @@ func Load(query *api.Query, Origin ed25519.PrivateKey, walletCount, txCount int)
 	return addrList, nil
 }
 
-func BuildTestSynthDepositGenTx(origin *ed25519.PrivateKey) (types.String, *ed25519.PrivateKey, *transactions.GenTransaction, error) {
+func BuildTestSynthDepositGenTx(origin ed25519.PrivateKey) (types.String, ed25519.PrivateKey, *transactions.GenTransaction, error) {
 	//use the public key of the bvc to make a sponsor address (this doesn't really matter right now, but need something so Identity of the BVC is good)
 	adiSponsor := types.String(anon.GenerateAcmeAddress(origin.Public().(ed25519.PublicKey)))
 
@@ -166,7 +165,7 @@ func BuildTestSynthDepositGenTx(origin *ed25519.PrivateKey) (types.String, *ed25
 
 	gtx.Signature = append(gtx.Signature, ed)
 
-	return destAddress, &privateKey, gtx, nil
+	return destAddress, privateKey, gtx, nil
 }
 
 func BuildTestTokenTxGenTx(origin *ed25519.PrivateKey, destAddr string, amount uint64) (*transactions.GenTransaction, error) {
@@ -203,7 +202,7 @@ func BuildTestTokenTxGenTx(origin *ed25519.PrivateKey, destAddr string, amount u
 	return gtx, nil
 }
 
-func RunLoadTest(query *api.Query, origin *ed25519.PrivateKey, walletCount, txCount int) (addrList []string, err error) {
+func RunLoadTest(query *api.Query, origin ed25519.PrivateKey, walletCount, txCount int) (addrList []string, err error) {
 	destAddress, privateKey, gtx, err := BuildTestSynthDepositGenTx(origin)
 	if err != nil {
 		return nil, err
@@ -229,7 +228,7 @@ func RunLoadTest(query *api.Query, origin *ed25519.PrivateKey, walletCount, txCo
 		return nil, fmt.Errorf("timeout while waiting for TX response")
 	}
 
-	addresses, err := Load(query, *privateKey, walletCount, txCount)
+	addresses, err := Load(query, privateKey, walletCount, txCount)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/testing/node.go
+++ b/internal/testing/node.go
@@ -3,6 +3,7 @@ package testing
 import (
 	"crypto/sha256"
 	"fmt"
+	"os"
 	"path/filepath"
 
 	cfg "github.com/AccumulateNetwork/accumulated/config"
@@ -14,6 +15,7 @@ import (
 	"github.com/AccumulateNetwork/accumulated/networks"
 	"github.com/AccumulateNetwork/accumulated/types/state"
 	tmcfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/privval"
 	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
 )
@@ -68,7 +70,7 @@ func NewBVCNode(dir string, cleanup func(func())) (*node.Node, *privval.FilePV, 
 		return nil, nil, fmt.Errorf("failed to open database %s: %v", dbPath, err)
 	}
 	cleanup(func() {
-		sdb.GetDB().Close()
+		_ = sdb.GetDB().Close()
 	})
 
 	// read private validator
@@ -90,17 +92,23 @@ func NewBVCNode(dir string, cleanup func(func())) (*node.Node, *privval.FilePV, 
 		return nil, nil, fmt.Errorf("failed to create chain manager: %v", err)
 	}
 
-	app, err := abci.NewAccumulator(sdb, pv.Key.PubKey.Address(), mgr)
+	logger, err := log.NewDefaultLogger(cfg.LogFormat, cfg.LogLevel, false)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: failed to parse log level: %v", err)
+		os.Exit(1)
+	}
+
+	app, err := abci.NewAccumulator(sdb, pv.Key.PubKey.Address(), mgr, logger)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create ABCI app: %v", err)
 	}
 
-	node, err := node.New(cfg, app)
+	node, err := node.New(cfg, app, logger)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create node: %v", err)
 	}
 	cleanup(func() {
-		node.Stop()
+		_ = node.Stop()
 		node.Wait()
 	})
 

--- a/smt/storage/database/manager.go
+++ b/smt/storage/database/manager.go
@@ -140,10 +140,8 @@ func (m *Manager) GetCount() int64 {
 
 // Close
 // Do any cleanup required to close the manager
-func (m *Manager) Close() {
-	if err := m.DB.Close(); err != nil {
-		panic(err)
-	}
+func (m *Manager) Close() error {
+	return m.DB.Close()
 }
 
 // AddBucket


### PR DESCRIPTION
- Add support for installing and running as a mac/windows/linux service.
- Cleans up error handling in `cmd/accumulated`
- Custom logging, to feed logs to the service system

It should be noted that in Windows, stdout/stderr of a service is not captured. In Windows, if logs are not written to the service logger, they may as well not exist. Logs written to the service logger are visible in the event viewer, but everything else goes into a void.