### PR TITLE
Fix database.Manager.SetAppID

### DIFF
--- a/internal/api/utils_test.go
+++ b/internal/api/utils_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/AccumulateNetwork/accumulated/config"
 	. "github.com/AccumulateNetwork/accumulated/internal/api"
 	"github.com/AccumulateNetwork/accumulated/internal/node"
 	"github.com/AccumulateNetwork/accumulated/internal/relay"
@@ -20,16 +21,18 @@ func startBVC(t *testing.T, dir string) (*node.Node, *privval.FilePV, *Query) {
 	require.NoError(t, err)
 	opts.WorkDir = dir
 	opts.Port = GetFreePort(t)
-
-	opts.Config[0].Mempool.MaxBatchBytes = 1048576
-	opts.Config[0].Mempool.CacheSize = 1048576
-	opts.Config[0].Mempool.Size = 50000
-
-	// https://github.com/tendermint/tendermint/issues/7076
-	opts.Config[0].Instrumentation.Prometheus = false
+	cfg := opts.Config[0]
+	cfg.Mempool.MaxBatchBytes = 1048576
+	cfg.Mempool.CacheSize = 1048576
+	cfg.Mempool.Size = 50000
 
 	require.NoError(t, node.Init(opts))                        // Configure
 	nodeDir := filepath.Join(dir, "Node0")                     //
+	cfg, err = config.Load(nodeDir)                            // Modify configuration
+	require.NoError(t, err)                                    //
+	cfg.Accumulate.WebsiteEnabled = false                      // Disable the website
+	cfg.Instrumentation.Prometheus = false                     // Disable prometheus: https://github.com/tendermint/tendermint/issues/7076
+	require.NoError(t, config.Store(cfg))                      //
 	node, pv, err := acctesting.NewBVCNode(nodeDir, t.Cleanup) // Initialize
 	require.NoError(t, err)                                    //
 	require.NoError(t, node.Start())                           // Launch

--- a/smt/storage/database/manager.go
+++ b/smt/storage/database/manager.go
@@ -91,7 +91,8 @@ func (m *Manager) SetAppID(appID []byte) {
 		m.AppID = nil //  to be used to write to the root level.  No need to
 		return        //  register it.
 	}
-	m.AppID = m.AppID[:0]                                 // clear the appID to get AppID data
+
+	m.AppID = nil                                         // clear the appID to get AppID data
 	appIDIdx := m.GetInt64("AppID", "AppID2Index", appID) // Sort index for existing AppID
 	if appIDIdx < 0 {                                     // A index < 0 => AppID does not exist
 		AppIDMutex.Lock()                          //       Lock AppID creation so creation is atomic
@@ -106,7 +107,8 @@ func (m *Manager) SetAppID(appID []byte) {
 		_ = m.PutInt64("AppID", "", []byte{}, count+1)                     // increment the count in the database.
 		AppIDMutex.Unlock()
 	}
-	m.AppID = append(m.AppID[:0], appID...) // copy the given appID over the current AppID
+	m.AppID = make([]byte, len(appID))
+	copy(m.AppID, appID) // copy the given appID over the current AppID
 }
 
 // CurrentAppID


### PR DESCRIPTION
The method had a non-pointer receiver, so the caller's AppID never got set. Plus, it was reusing the slice, which could result in the various managers reusing the same underlying slice.