### PR TITLE
Refactor chain validator state management

### DIFF
--- a/internal/abci/accumulator_test.go
+++ b/internal/abci/accumulator_test.go
@@ -81,7 +81,7 @@ func (s *AccumulatorTestSuite) TestCheckTx() {
 		destAddr := "wyleecoyote/acme"
 		//make an unreasonable amount sure
 		amount := uint64(1000000000)
-		tx, err := testing2.BuildTestTokenTxGenTx(&origin, destAddr, amount)
+		tx, err := testing2.BuildTestTokenTxGenTx(origin, destAddr, amount)
 		//now corrupt the validation for the signature
 		tx.Signature[0].Nonce = 9999999
 
@@ -130,7 +130,7 @@ func (s *AccumulatorTestSuite) TestDeliverTx() {
 		destAddr := "wyleecoyote/acme"
 		//make an unreasonable amount sure
 		amount := uint64(1000000000)
-		tx, err := testing2.BuildTestTokenTxGenTx(&origin, destAddr, amount)
+		tx, err := testing2.BuildTestTokenTxGenTx(origin, destAddr, amount)
 
 		data, err := tx.Marshal()
 		s.Require().NoError(err)

--- a/internal/api/jsonrpc.go
+++ b/internal/api/jsonrpc.go
@@ -510,7 +510,7 @@ func (api *API) faucet(_ context.Context, params json.RawMessage) interface{} {
 	tokenUrl := types.String(protocol.AcmeUrl().String())
 
 	//create a fake synthetic deposit for faucet.
-	deposit := synthetic.NewTokenTransactionDeposit(txid[:], &fromAccount, &destAccount)
+	deposit := synthetic.NewTokenTransactionDeposit(txid[:], fromAccount, destAccount)
 	amtToDeposit := int64(10)                                //deposit 50k tokens
 	deposit.DepositAmount.SetInt64(amtToDeposit * 100000000) // assume 8 decimal places
 	deposit.TokenUrl = tokenUrl

--- a/internal/chain/README.md
+++ b/internal/chain/README.md
@@ -1,0 +1,11 @@
+## Chain Validator Design
+
+Chain validators are organized by transaction type. The executor handles mundane
+tasks that are common to all chain validators, such as authentication and
+authorization.
+
+In general, every transaction requires a sponsor. Thus, the executor validates
+and loads the sponsor before delegating to the chain validator. However, certain
+transaction types, specifically synthetic transactions that create records, may
+not need an extant sponsor. The executor has a specific clause for these special
+cases.

--- a/internal/chain/_token_issuance.go
+++ b/internal/chain/_token_issuance.go
@@ -14,11 +14,11 @@ type TokenIssuance struct{}
 
 func (TokenIssuance) Type() types.TxType { return types.TxTypeTokenCreate }
 
-func (TokenIssuance) CheckTx(st *state.StateEntry, tx *transactions.GenTransaction) error {
+func (TokenIssuance) CheckTx(st *StateManager, tx *transactions.GenTransaction) error {
 	return nil
 }
 
-func (TokenIssuance) DeliverTx(st *state.StateEntry, tx *transactions.GenTransaction) (*DeliverTxResult, error) {
+func (TokenIssuance) DeliverTx(st *StateManager, tx *transactions.GenTransaction) error {
 	if err := tx.SetRoutingChainID(); err != nil {
 		return nil, err
 	}

--- a/internal/chain/add_credits.go
+++ b/internal/chain/add_credits.go
@@ -15,11 +15,7 @@ type AddCredits struct{}
 
 func (AddCredits) Type() types.TxType { return types.TxTypeAddCredits }
 
-func checkAddCredits(st *state.StateEntry, tx *transactions.GenTransaction) (body *protocol.AddCredits, account tokenChain, amount *types.Amount, recipient *url.URL, err error) {
-	if st.ChainHeader == nil {
-		return nil, nil, nil, nil, fmt.Errorf("sponsor not found")
-	}
-
+func checkAddCredits(st *StateManager, tx *transactions.GenTransaction) (body *protocol.AddCredits, account tokenChain, amount *types.Amount, recipient *url.URL, err error) {
 	body = new(protocol.AddCredits)
 	err = tx.As(body)
 	if err != nil {
@@ -43,16 +39,16 @@ func checkAddCredits(st *state.StateEntry, tx *transactions.GenTransaction) (bod
 		return nil, nil, nil, nil, fmt.Errorf("invalid recipient")
 	}
 
-	_, recvChain, err := st.DB.LoadChain(recvUrl.ResourceChain())
+	recv, err := st.LoadUrl(recvUrl)
 	if err == nil {
 		// If the recipient happens to be on the same BVC, ensure it is a valid
 		// recipient. Most credit transfers will be within the same ADI, so this
 		// should catch most mistakes early.
-		switch recvChain.Type {
-		case types.ChainTypeAnonTokenAccount, types.ChainTypeSigSpec:
+		switch recv := recv.(type) {
+		case *protocol.AnonTokenAccount, *protocol.SigSpec:
 			// OK
 		default:
-			return nil, nil, nil, nil, fmt.Errorf("invalid recipient: wrong chain type: want %v or %v, got %v", types.ChainTypeAnonTokenAccount, types.ChainTypeSigSpec, recvChain.Type)
+			return nil, nil, nil, nil, fmt.Errorf("invalid recipient: wrong chain type: want %v or %v, got %v", types.ChainTypeAnonTokenAccount, types.ChainTypeSigSpec, recv.Header().Type)
 		}
 	} else if errors.Is(err, state.ErrNotFound) {
 		if recvUrl.Routing() == tx.Routing {
@@ -65,18 +61,13 @@ func checkAddCredits(st *state.StateEntry, tx *transactions.GenTransaction) (bod
 		return nil, nil, nil, nil, fmt.Errorf("failed to load recipient: %v", err)
 	}
 
-	switch st.ChainHeader.Type {
-	case types.ChainTypeAnonTokenAccount:
-		account = new(protocol.AnonTokenAccount)
-	case types.ChainTypeTokenAccount:
-		account = new(state.TokenAccount)
+	switch sponsor := st.Sponsor.(type) {
+	case *protocol.AnonTokenAccount:
+		account = sponsor
+	case *state.TokenAccount:
+		account = sponsor
 	default:
 		return nil, nil, nil, nil, fmt.Errorf("not an account: %q", tx.SigInfo.URL)
-	}
-
-	err = st.ChainState.As(account)
-	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("invalid token account: %v", err)
 	}
 
 	tokenUrl, err := account.ParseTokenUrl()
@@ -96,44 +87,27 @@ func checkAddCredits(st *state.StateEntry, tx *transactions.GenTransaction) (bod
 	return body, account, amount, recvUrl, nil
 }
 
-func (AddCredits) CheckTx(st *state.StateEntry, tx *transactions.GenTransaction) error {
+func (AddCredits) CheckTx(st *StateManager, tx *transactions.GenTransaction) error {
 	_, _, _, _, err := checkAddCredits(st, tx)
 	return err
 }
 
-func (AddCredits) DeliverTx(st *state.StateEntry, tx *transactions.GenTransaction) (*DeliverTxResult, error) {
+func (AddCredits) DeliverTx(st *StateManager, tx *transactions.GenTransaction) error {
 	body, account, amount, recipient, err := checkAddCredits(st, tx)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	if !account.DebitTokens(&amount.Int) {
-		return nil, fmt.Errorf("failed to debit %v", tx.SigInfo.URL)
+		return fmt.Errorf("failed to debit %v", tx.SigInfo.URL)
 	}
-
-	st.ChainState.Entry, err = account.MarshalBinary()
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal state: %v", err)
-	}
+	st.Store(account)
 
 	// Create the synthetic transaction
-	txid := types.Bytes(tx.TransactionHash()).AsBytes32()
 	sdc := new(protocol.SyntheticDepositCredits)
-	sdc.Cause = txid
+	sdc.Cause = types.Bytes(tx.TransactionHash()).AsBytes32()
 	sdc.Amount = body.Amount
+	st.Submit(recipient, sdc)
 
-	syn := new(transactions.GenTransaction)
-	syn.SigInfo = &transactions.SignatureInfo{}
-	syn.SigInfo.URL = recipient.String()
-	syn.Transaction, err = sdc.MarshalBinary()
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal synthetic TX: %v", err)
-	}
-
-	// Update the account state
-	st.DB.AddStateEntry(st.ChainId, &txid, st.ChainState)
-
-	res := new(DeliverTxResult)
-	res.AddSyntheticTransaction(syn)
-	return res, nil
+	return nil
 }

--- a/internal/chain/chain.go
+++ b/internal/chain/chain.go
@@ -2,7 +2,6 @@ package chain
 
 import (
 	"crypto/ed25519"
-	"fmt"
 	"math/big"
 
 	accapi "github.com/AccumulateNetwork/accumulated/internal/api"
@@ -32,10 +31,10 @@ type TxExecutor interface {
 	Type() types.TxType
 
 	// CheckTx partially validates the transaction.
-	CheckTx(*state.StateEntry, *transactions.GenTransaction) error
+	CheckTx(*StateManager, *transactions.GenTransaction) error
 
 	// DeliverTx fully validates and executes the transaction.
-	DeliverTx(*state.StateEntry, *transactions.GenTransaction) (*DeliverTxResult, error)
+	DeliverTx(*StateManager, *transactions.GenTransaction) error
 }
 
 type creditChain interface {
@@ -51,27 +50,4 @@ type tokenChain interface {
 	CreditTokens(amount *big.Int) bool
 	CanDebitTokens(amount *big.Int) bool
 	DebitTokens(amount *big.Int) bool
-}
-
-type DeliverTxResult struct {
-	SyntheticTransactions []*transactions.GenTransaction //this is a list of synthetic transactions
-	Chains                map[[32]byte]state.Chain
-}
-
-func (r *DeliverTxResult) AddSyntheticTransaction(tx *transactions.GenTransaction) {
-	r.SyntheticTransactions = append(r.SyntheticTransactions, tx)
-}
-
-func (r *DeliverTxResult) AddChain(ch state.Chain) {
-	u, err := url.Parse(ch.GetChainUrl())
-	if err != nil {
-		// The caller must ensure the chain URL is correct
-		panic(fmt.Errorf("attempted to add an invalid chain: %v", err))
-	}
-	if r.Chains == nil {
-		r.Chains = map[[32]byte]state.Chain{}
-	}
-	var chainId [32]byte
-	copy(chainId[:], u.ResourceChain())
-	r.Chains[chainId] = ch
 }

--- a/internal/chain/create_sig_spec.go
+++ b/internal/chain/create_sig_spec.go
@@ -1,7 +1,6 @@
 package chain
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/AccumulateNetwork/accumulated/internal/url"
@@ -15,32 +14,19 @@ type CreateSigSpec struct{}
 
 func (CreateSigSpec) Type() types.TxType { return types.TxTypeCreateSigSpec }
 
-func checkCreateSigSpec(st *state.StateEntry, tx *transactions.GenTransaction) (*protocol.CreateSigSpec, *protocol.SigSpecGroup, *url.URL, error) {
-	adiUrl, err := url.Parse(tx.SigInfo.URL)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("invalid sponsor URL: %v", err)
-	}
-
-	if st.ChainHeader == nil {
-		return nil, nil, nil, fmt.Errorf("sponsor not found")
-	}
-
+func checkCreateSigSpec(st *StateManager, tx *transactions.GenTransaction) (*protocol.CreateSigSpec, *protocol.SigSpecGroup, *url.URL, error) {
 	var group *protocol.SigSpecGroup
-	switch st.ChainHeader.Type {
-	case types.ChainTypeAdi:
+	switch sponsor := st.Sponsor.(type) {
+	case *state.AdiState:
 		// Create an unbound sig spec
-	case types.ChainTypeSigSpecGroup:
-		group = new(protocol.SigSpecGroup)
-		err = st.ChainState.As(group)
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("failed to decode sponsor: %v", err)
-		}
+	case *protocol.SigSpecGroup:
+		group = sponsor
 	default:
-		return nil, nil, nil, fmt.Errorf("%v cannot sponsor a sig spec", st.ChainHeader.Type)
+		return nil, nil, nil, fmt.Errorf("%v cannot sponsor a sig spec", sponsor.Header().Type)
 	}
 
 	body := new(protocol.CreateSigSpec)
-	err = tx.As(body)
+	err := tx.As(body)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("invalid payload: %v", err)
 	}
@@ -54,38 +40,37 @@ func checkCreateSigSpec(st *state.StateEntry, tx *transactions.GenTransaction) (
 		return nil, nil, nil, fmt.Errorf("invalid target URL: %v", err)
 	}
 
-	if !bytes.Equal(adiUrl.IdentityChain(), msUrl.IdentityChain()) {
-		return nil, nil, nil, fmt.Errorf("%q does not belong to %q", msUrl, adiUrl)
+	if !msUrl.Identity().Equal(st.SponsorUrl.Identity()) {
+		return nil, nil, nil, fmt.Errorf("%q does not belong to %q", msUrl, st.SponsorUrl)
 	}
 
 	return body, group, msUrl, nil
 }
 
-func (CreateSigSpec) CheckTx(st *state.StateEntry, tx *transactions.GenTransaction) error {
+func (CreateSigSpec) CheckTx(st *StateManager, tx *transactions.GenTransaction) error {
 	_, _, _, err := checkCreateSigSpec(st, tx)
 	return err
 }
 
-func (CreateSigSpec) DeliverTx(st *state.StateEntry, tx *transactions.GenTransaction) (*DeliverTxResult, error) {
+func (CreateSigSpec) DeliverTx(st *StateManager, tx *transactions.GenTransaction) error {
 	body, group, url, err := checkCreateSigSpec(st, tx)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	res := new(DeliverTxResult)
 	spec := protocol.NewSigSpec()
 	spec.ChainUrl = types.String(url.String())
-	res.AddChain(spec)
+	st.Store(spec)
 
 	if group != nil {
 		groupUrl, err := group.ParseUrl()
 		if err != nil {
 			// Failing here would require writing an invalid URL to the state.
 			// But stuff happens, so don't panic.
-			return nil, fmt.Errorf("invalid sponsor URL: %v", err)
+			return fmt.Errorf("invalid sponsor URL: %v", err)
 		}
 
-		res.AddChain(group)
+		st.Store(group)
 		group.SigSpecs = append(group.SigSpecs, types.Bytes(url.ResourceChain()).AsBytes32())
 		spec.SigSpecId = types.Bytes(groupUrl.ResourceChain()).AsBytes32()
 	}
@@ -98,5 +83,5 @@ func (CreateSigSpec) DeliverTx(st *state.StateEntry, tx *transactions.GenTransac
 		spec.Keys = append(spec.Keys, ss)
 	}
 
-	return res, nil
+	return nil
 }

--- a/internal/chain/create_sig_spec_group.go
+++ b/internal/chain/create_sig_spec_group.go
@@ -1,7 +1,6 @@
 package chain
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/AccumulateNetwork/accumulated/internal/url"
@@ -15,22 +14,13 @@ type CreateSigSpecGroup struct{}
 
 func (CreateSigSpecGroup) Type() types.TxType { return types.TxTypeCreateSigSpecGroup }
 
-func checkCreateSigSpecGroup(st *state.StateEntry, tx *transactions.GenTransaction) ([]*protocol.SigSpec, *url.URL, error) {
-	adiUrl, err := url.Parse(tx.SigInfo.URL)
-	if err != nil {
-		return nil, nil, fmt.Errorf("invalid sponsor URL: %v", err)
-	}
-
-	if st.ChainHeader == nil {
-		return nil, nil, fmt.Errorf("sponsor not found")
-	}
-
-	if st.ChainHeader.Type != types.ChainTypeAdi {
-		return nil, nil, fmt.Errorf("%q is not an ADI", tx.SigInfo.URL)
+func checkCreateSigSpecGroup(st *StateManager, tx *transactions.GenTransaction) ([]*protocol.SigSpec, *url.URL, error) {
+	if _, ok := st.Sponsor.(*state.AdiState); !ok {
+		return nil, nil, fmt.Errorf("invalid sponsor: want %v, got %v", types.ChainTypeAdi, st.Sponsor.Header().Type)
 	}
 
 	body := new(protocol.CreateSigSpecGroup)
-	err = tx.As(body)
+	err := tx.As(body)
 	if err != nil {
 		return nil, nil, fmt.Errorf("invalid payload: %v", err)
 	}
@@ -44,14 +34,14 @@ func checkCreateSigSpecGroup(st *state.StateEntry, tx *transactions.GenTransacti
 		return nil, nil, fmt.Errorf("invalid target URL: %v", err)
 	}
 
-	if !bytes.Equal(adiUrl.IdentityChain(), sgUrl.IdentityChain()) {
-		return nil, nil, fmt.Errorf("%q does not belong to %q", sgUrl, adiUrl)
+	if !sgUrl.Identity().Equal(st.SponsorUrl) {
+		return nil, nil, fmt.Errorf("%q does not belong to %q", sgUrl, st.SponsorUrl)
 	}
 
 	entries := make([]*protocol.SigSpec, len(body.SigSpecs))
 	for i, chainId := range body.SigSpecs {
 		entry := new(protocol.SigSpec)
-		_, err := st.DB.LoadChainAs(chainId[:], entry)
+		err = st.LoadAs(chainId, entry)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to fetch sig spec: %v", err)
 		}
@@ -62,8 +52,8 @@ func checkCreateSigSpecGroup(st *state.StateEntry, tx *transactions.GenTransacti
 			return nil, nil, fmt.Errorf("invalid sig spec state: bad URL: %v", err)
 		}
 
-		if !bytes.Equal(adiUrl.IdentityChain(), u.IdentityChain()) {
-			return nil, nil, fmt.Errorf("%q does not belong to %q", u, adiUrl)
+		if !u.Identity().Equal(st.SponsorUrl) {
+			return nil, nil, fmt.Errorf("%q does not belong to %q", u, st.SponsorUrl)
 		}
 
 		if (entry.SigSpecId != types.Bytes32{}) {
@@ -76,35 +66,34 @@ func checkCreateSigSpecGroup(st *state.StateEntry, tx *transactions.GenTransacti
 	return entries, sgUrl, nil
 }
 
-func (CreateSigSpecGroup) CheckTx(st *state.StateEntry, tx *transactions.GenTransaction) error {
+func (CreateSigSpecGroup) CheckTx(st *StateManager, tx *transactions.GenTransaction) error {
 	_, _, err := checkCreateSigSpecGroup(st, tx)
 	return err
 }
 
-func (CreateSigSpecGroup) DeliverTx(st *state.StateEntry, tx *transactions.GenTransaction) (*DeliverTxResult, error) {
+func (CreateSigSpecGroup) DeliverTx(st *StateManager, tx *transactions.GenTransaction) error {
 	entries, url, err := checkCreateSigSpecGroup(st, tx)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	ssg := protocol.NewSigSpecGroup()
 	ssg.ChainUrl = types.String(url.String())
-	res := new(DeliverTxResult)
-	res.AddChain(ssg)
+	st.Store(ssg)
 
 	groupChainId := types.Bytes(url.ResourceChain()).AsBytes32()
 	for _, spec := range entries {
 		u, err := spec.ParseUrl()
 		if err != nil {
 			// We already did this, so this should never fail here.
-			return nil, fmt.Errorf("invalid sig spec state: bad URL: %v", err)
+			return fmt.Errorf("invalid sig spec state: bad URL: %v", err)
 		}
 
 		specChainId := types.Bytes(u.ResourceChain()).AsBytes32()
 		ssg.SigSpecs = append(ssg.SigSpecs, specChainId)
 		spec.SigSpecId = groupChainId
-		res.AddChain(spec)
+		st.Store(spec)
 	}
 
-	return res, nil
+	return nil
 }

--- a/internal/chain/executor.go
+++ b/internal/chain/executor.go
@@ -87,99 +87,98 @@ func (m *Executor) BeginBlock(req abci.BeginBlockRequest) {
 	m.chainWG = make(map[uint64]*sync.WaitGroup, chainWGSize)
 }
 
-func (m *Executor) check(st *state.StateEntry, tx *transactions.GenTransaction) error {
+func (m *Executor) check(tx *transactions.GenTransaction) (*StateManager, error) {
 	if len(tx.Signature) == 0 {
-		return fmt.Errorf("transaction is not signed")
-	}
-
-	txt := tx.TransactionType()
-	if txt.IsSynthetic() {
-		return m.checkSynthetic(st, tx)
-	}
-
-	if st.ChainHeader == nil {
-		return fmt.Errorf("sponsor not found")
+		return nil, fmt.Errorf("transaction is not signed")
 	}
 
 	if !tx.ValidateSig() {
-		return fmt.Errorf("invalid signature")
+		return nil, fmt.Errorf("invalid signature")
 	}
 
-	ssg := new(protocol.SigSpecGroup)
-	switch st.ChainHeader.Type {
-	case types.ChainTypeAnonTokenAccount:
-		return m.checkAnonymous(st, tx)
+	txt := tx.TransactionType()
 
-	case types.ChainTypeAdi, types.ChainTypeTokenAccount, types.ChainTypeSigSpec:
-		_, err := m.db.LoadChainAs(st.ChainHeader.SigSpecId[:], ssg)
+	st, err := NewStateManager(m.db, tx)
+	if errors.Is(err, state.ErrNotFound) {
+		switch txt {
+		case types.TxTypeSyntheticCreateChain, types.TxTypeSyntheticTokenDeposit:
+			// TX does not require a sponsor - it may create the sponsor
+		default:
+			return nil, fmt.Errorf("sponsor not found: %v", err)
+		}
+	} else if err != nil {
+		return nil, err
+	}
+
+	if txt.IsSynthetic() {
+		return st, m.checkSynthetic(st, tx)
+	}
+
+	sigGroup := new(protocol.SigSpecGroup)
+	switch sponsor := st.Sponsor.(type) {
+	case *protocol.AnonTokenAccount:
+		return st, m.checkAnonymous(st, tx, sponsor)
+
+	case *state.AdiState, *state.TokenAccount, *protocol.SigSpec:
+		if (sponsor.Header().SigSpecId == types.Bytes32{}) {
+			return nil, fmt.Errorf("sponsor has not been assigned to an SSG")
+		}
+		err := st.LoadAs(sponsor.Header().SigSpecId, sigGroup)
 		if err != nil {
-			return fmt.Errorf("failed to load sig spec group: %v", err)
+			return nil, fmt.Errorf("invalid SigSpecId: %v", err)
 		}
 
-	case types.ChainTypeSigSpecGroup:
-		err := st.ChainState.As(ssg)
-		if err != nil {
-			return fmt.Errorf("failed to decode sponsor: %v", err)
-		}
+	case *protocol.SigSpecGroup:
+		sigGroup = sponsor
 
 	default:
 		// The TX sponsor cannot be a transaction
 		// Token issue chains are not implemented
-		return fmt.Errorf("%v cannot sponsor transactions", st.ChainHeader.Type)
+		return nil, fmt.Errorf("%v cannot sponsor transactions", sponsor.Header().Type)
 	}
 
-	if tx.SigInfo.PriorityIdx >= uint64(len(ssg.SigSpecs)) {
-		return fmt.Errorf("invalid sig spec index")
+	if tx.SigInfo.PriorityIdx >= uint64(len(sigGroup.SigSpecs)) {
+		return nil, fmt.Errorf("invalid sig spec index")
 	}
 
-	ss := new(protocol.SigSpec)
-	_, err := m.db.LoadChainAs(ssg.SigSpecs[tx.SigInfo.PriorityIdx][:], ss)
+	sigSpec := new(protocol.SigSpec)
+	err = st.LoadAs(sigGroup.SigSpecs[tx.SigInfo.PriorityIdx], sigSpec)
 	if err != nil {
-		return fmt.Errorf("failed to load sig spec: %v", err)
+		return nil, fmt.Errorf("invalid sig spec: %v", err)
 	}
 
 	// TODO check height
 
 	for i, sig := range tx.Signature {
-		ks, err := ss.FindKey(sig.PublicKey, protocol.ED25519)
+		ks, err := sigSpec.FindKey(sig.PublicKey, protocol.ED25519)
 		if err != nil {
-			return fmt.Errorf("failed to verify signature %d: %v", i, err)
+			return nil, fmt.Errorf("failed to verify signature %d: %v", i, err)
 		}
 
 		if ks == nil {
-			return fmt.Errorf("no key spec matches signature %d", i)
+			return nil, fmt.Errorf("no key spec matches signature %d", i)
 		}
 
 		if ks.Nonce >= sig.Nonce {
-			return fmt.Errorf("invalid nonce")
+			return nil, fmt.Errorf("invalid nonce")
 		}
 		// TODO add pending update for the nonce
 	}
 
-	return nil
+	return st, nil
 }
 
-func (m *Executor) checkSynthetic(st *state.StateEntry, tx *transactions.GenTransaction) error {
+func (m *Executor) checkSynthetic(st *StateManager, tx *transactions.GenTransaction) error {
 	//placeholder for special validation rules for synthetic transactions.
 	//need to verify the sender is a legit bvc validator also need the dbvc receipt
 	//so if the transaction is a synth tx, then we need to verify the sender is a BVC validator and
 	//not an impostor. Need to figure out how to do this. Right now we just assume the synth request
 	//sender is legit.
-
-	if !tx.ValidateSig() {
-		return fmt.Errorf("invalid signature")
-	}
 	return nil
 }
 
-func (m *Executor) checkAnonymous(st *state.StateEntry, tx *transactions.GenTransaction) error {
-	account := new(protocol.AnonTokenAccount)
-	err := st.ChainState.As(account)
-	if err != nil {
-		return fmt.Errorf("failed to decode sponsor: %v", err)
-	}
-
-	u, err := st.ChainHeader.ParseUrl()
+func (m *Executor) checkAnonymous(st *StateManager, tx *transactions.GenTransaction, account *protocol.AnonTokenAccount) error {
+	u, err := account.ParseUrl()
 	if err != nil {
 		// This shouldn't happen because invalid URLs should never make it
 		// into the database.
@@ -216,14 +215,7 @@ func (m *Executor) CheckTx(tx *transactions.GenTransaction) error {
 		return err
 	}
 
-	m.mu.Lock()
-	st, err := m.db.LoadChainState(tx.ChainID)
-	m.mu.Unlock()
-	if err != nil {
-		return fmt.Errorf("failed to get state for : %v", err)
-	}
-
-	err = m.check(st, tx)
+	st, err := m.check(tx)
 	if err != nil {
 		return err
 	}
@@ -275,12 +267,7 @@ func (m *Executor) DeliverTx(tx *transactions.GenTransaction) (*protocol.TxResul
 	defer group.Done()
 	m.mu.Unlock()
 
-	st, err := m.db.LoadChainState(tx.ChainID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get state: %v", err)
-	}
-
-	err = m.check(st, tx)
+	st, err := m.check(tx)
 	if err != nil {
 		return nil, err
 	}
@@ -290,7 +277,7 @@ func (m *Executor) DeliverTx(tx *transactions.GenTransaction) (*protocol.TxResul
 
 	// Validate
 	// TODO result should return a list of chainId's the transaction touched.
-	result, err := executor.DeliverTx(st, tx)
+	err = executor.DeliverTx(st, tx)
 	if err != nil {
 		return nil, fmt.Errorf("rejected by chain: %v", err)
 	}
@@ -321,8 +308,11 @@ func (m *Executor) DeliverTx(tx *transactions.GenTransaction) (*protocol.TxResul
 
 	// Store pending state changes
 	txHash := types.Bytes(tx.TransactionHash()).AsBytes32()
-	for id, chain := range result.Chains {
-		data, err := chain.MarshalBinary()
+	for id, entry := range st.chains {
+		if !entry.dirty {
+			continue
+		}
+		data, err := entry.record.MarshalBinary()
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal state: %v", err)
 		}
@@ -337,12 +327,8 @@ func (m *Executor) DeliverTx(tx *transactions.GenTransaction) (*protocol.TxResul
 		return nil, err
 	}
 
-	if result == nil {
-		return nil, errors.New("no chain validation")
-	}
-
 	// Process synthetic transactions generated by the validator
-	refs, err := m.submitSyntheticTx(tx.TransactionHash(), result)
+	refs, err := m.submitSyntheticTx(tx.TransactionHash(), st)
 	if err != nil {
 		return nil, err
 	}
@@ -365,21 +351,22 @@ func (m *Executor) Commit() ([]byte, error) {
 		panic(fmt.Errorf("fatal error, block not set, %v", err))
 	}
 
-	// If we have no transactions this block then don't publish anything
-	if m.leader && numStateChanges > 0 {
-		// Now we create a synthetic transaction and publish to the directory
-		// block validator
-		dbvc := DeliverTxResult{}
-		dbvc.SyntheticTransactions = make([]*transactions.GenTransaction, 1)
-		dbvc.SyntheticTransactions[0] = &transactions.GenTransaction{}
-		dcAdi := "dc"
-		dbvc.SyntheticTransactions[0].ChainID = types.GetChainIdFromChainPath(&dcAdi).Bytes()
-		dbvc.SyntheticTransactions[0].Routing = types.GetAddressFromIdentity(&dcAdi)
-		//dbvc.Submissions[0].Transaction = ...
+	_ = numStateChanges
+	// // If we have no transactions this block then don't publish anything
+	// if m.leader && numStateChanges > 0 {
+	// 	// Now we create a synthetic transaction and publish to the directory
+	// 	// block validator
+	// 	dbvc := DeliverTxResult{}
+	// 	dbvc.SyntheticTransactions = make([]*transactions.GenTransaction, 1)
+	// 	dbvc.SyntheticTransactions[0] = &transactions.GenTransaction{}
+	// 	dcAdi := "dc"
+	// 	dbvc.SyntheticTransactions[0].ChainID = types.GetChainIdFromChainPath(&dcAdi).Bytes()
+	// 	dbvc.SyntheticTransactions[0].Routing = types.GetAddressFromIdentity(&dcAdi)
+	// 	//dbvc.Submissions[0].Transaction = ...
 
-		//broadcast the root
-		//m.processValidatedSubmissionRequest(&dbvc)
-	}
+	// 	//broadcast the root
+	// 	//m.processValidatedSubmissionRequest(&dbvc)
+	// }
 
 	m.query.BatchSend()
 
@@ -388,26 +375,26 @@ func (m *Executor) Commit() ([]byte, error) {
 	return mdRoot, nil
 }
 
-func (m *Executor) submitSyntheticTx(parentTxId types.Bytes, vtx *DeliverTxResult) (tmRef []*protocol.TxSynthRef, err error) {
+func (m *Executor) submitSyntheticTx(parentTxId types.Bytes, st *StateManager) (tmRef []*protocol.TxSynthRef, err error) {
 	if m.leader {
-		tmRef = make([]*protocol.TxSynthRef, len(vtx.SyntheticTransactions))
+		tmRef = make([]*protocol.TxSynthRef, len(st.submissions))
 	}
 
 	// Need to pass this to a threaded batcher / dispatcher to do both signing
 	// and sending of synth tx. No need to spend valuable time here doing that.
-	for i, tx := range vtx.SyntheticTransactions {
+	for i, sub := range st.submissions {
 		// Generate a synthetic tx and send to the router. Need to track txid to
 		// make sure they get processed.
 
-		if tx.Transaction == nil {
-			// This should never happen
-			return nil, fmt.Errorf("submission is missing its synthetic transaction")
+		body, err := sub.body.MarshalBinary()
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal synthetic transaction payload: %v", err)
 		}
 
-		if tx.SigInfo == nil {
-			// This should never happen
-			return nil, fmt.Errorf("synthetic transaction is missing its signature info")
-		}
+		tx := new(transactions.GenTransaction)
+		tx.SigInfo = new(transactions.SignatureInfo)
+		tx.SigInfo.URL = sub.url.String()
+		tx.Transaction = body
 
 		tx.SigInfo.Unused2 = m.nonce
 		m.nonce++ //TODO: make the nonce managed via the BVC admin state for synth tx rather than this way

--- a/internal/chain/state.go
+++ b/internal/chain/state.go
@@ -1,0 +1,201 @@
+package chain
+
+import (
+	"encoding"
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/AccumulateNetwork/accumulated/internal/url"
+	"github.com/AccumulateNetwork/accumulated/protocol"
+	"github.com/AccumulateNetwork/accumulated/types"
+	"github.com/AccumulateNetwork/accumulated/types/api/transactions"
+	"github.com/AccumulateNetwork/accumulated/types/state"
+)
+
+type StateManager struct {
+	db          *state.StateDB
+	chains      map[[32]byte]*stateEntry
+	submissions []*submittedTx
+
+	Sponsor        state.Chain
+	SponsorUrl     *url.URL
+	SponsorChainId [32]byte
+}
+
+func NewStateManager(db *state.StateDB, tx *transactions.GenTransaction) (*StateManager, error) {
+	st := new(StateManager)
+	st.db = db
+
+	var err error
+	st.SponsorUrl, err = url.Parse(tx.SigInfo.URL)
+	if err != nil {
+		return nil, err
+	}
+
+	copy(st.SponsorChainId[:], st.SponsorUrl.ResourceChain())
+	st.Sponsor, err = st.Load(st.SponsorChainId)
+	if err == nil {
+		return st, nil
+	}
+
+	if errors.Is(err, state.ErrNotFound) {
+		return st, fmt.Errorf("sponsor %q %w", st.SponsorUrl, err)
+	}
+	return nil, err
+}
+
+type stateEntry struct {
+	record state.Chain
+	dirty  bool
+}
+
+type submittedTx struct {
+	url  *url.URL
+	body encoding.BinaryMarshaler
+}
+
+func (m *StateManager) LoadString(s string) (state.Chain, error) {
+	u, err := url.Parse(s)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL: %v", err)
+	}
+
+	return m.LoadUrl(u)
+}
+
+func (m *StateManager) LoadUrl(u *url.URL) (state.Chain, error) {
+	var chainId [32]byte
+	copy(chainId[:], u.ResourceChain())
+	return m.Load(chainId)
+}
+
+func (m *StateManager) LoadStringAs(s string, v interface{}) error {
+	u, err := url.Parse(s)
+	if err != nil {
+		return fmt.Errorf("invalid URL: %v", err)
+	}
+
+	return m.LoadUrlAs(u, v)
+}
+
+func (m *StateManager) LoadUrlAs(u *url.URL, v interface{}) error {
+	var chainId [32]byte
+	copy(chainId[:], u.ResourceChain())
+	return m.LoadAs(chainId, v)
+}
+
+// Load loads the given chain and unmarshals it
+func (m *StateManager) Load(chainId [32]byte) (state.Chain, error) {
+	entry, ok := m.chains[chainId]
+	if ok {
+		return entry.record, nil
+	}
+
+	obj, err := m.db.GetCurrentEntry(chainId[:])
+	if err != nil {
+		return nil, err
+	}
+
+	record, err := unmarshalRecord(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	entry = new(stateEntry)
+	entry.record = record
+
+	if m.chains == nil {
+		m.chains = map[[32]byte]*stateEntry{}
+	}
+	m.chains[chainId] = entry
+	return record, nil
+}
+
+func (m *StateManager) LoadAs(chainId [32]byte, v interface{}) (err error) {
+	record, err := m.Load(chainId)
+	if err != nil {
+		return err
+	}
+
+	rv := reflect.ValueOf(v)
+	rr := reflect.ValueOf(record)
+	if !rr.Type().AssignableTo(rv.Type()) {
+		return fmt.Errorf("want %T, got %T", v, record)
+	}
+
+	// Catch reflection panic
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("failed to load chain: unable to write to %T", v)
+		}
+	}()
+	rv.Elem().Set(rr.Elem())
+	return nil
+}
+
+// Store queues a record for storage in the database
+func (m *StateManager) Store(record state.Chain) {
+	u, err := record.Header().ParseUrl()
+	if err != nil {
+		// The caller must ensure the chain URL is correct
+		panic(fmt.Errorf("attempted to add an invalid chain: %v", err))
+	}
+
+	var chainId [32]byte
+	copy(chainId[:], u.ResourceChain())
+	entry, ok := m.chains[chainId]
+	if !ok {
+		if m.chains == nil {
+			m.chains = map[[32]byte]*stateEntry{}
+		}
+		entry = new(stateEntry)
+		m.chains[chainId] = entry
+	}
+
+	entry.dirty = true
+	entry.record = record
+}
+
+// Submit queues a synthetic transaction for submission
+func (m *StateManager) Submit(url *url.URL, body encoding.BinaryMarshaler) {
+	m.submissions = append(m.submissions, &submittedTx{url, body})
+}
+
+func unmarshalRecord(obj *state.Object) (state.Chain, error) {
+	header := new(state.ChainHeader)
+	err := obj.As(header)
+	if err != nil {
+		return nil, err
+	}
+
+	var record state.Chain
+	switch header.Type {
+	// TODO DC, BVC, Token
+	case types.ChainTypeAdi:
+		record = new(state.AdiState)
+	case types.ChainTypeTokenAccount:
+		record = new(state.TokenAccount)
+	case types.ChainTypeAnonTokenAccount:
+		record = new(protocol.AnonTokenAccount)
+	case types.ChainTypeTransactionReference:
+		record = new(state.TxReference)
+	case types.ChainTypeTransaction:
+		record = new(state.Transaction)
+	case types.ChainTypePendingTransaction:
+		record = new(state.PendingTransaction)
+	case types.ChainTypeSigSpec:
+		record = new(protocol.SigSpec)
+	case types.ChainTypeSigSpecGroup:
+		record = new(protocol.SigSpecGroup)
+	default:
+		return nil, fmt.Errorf("unrecognized chain type %v", header.Type)
+	}
+
+	err = obj.As(record)
+	if err != nil {
+		return nil, err
+	}
+
+	return record, nil
+}

--- a/internal/chain/synthetic_token_deposit_test.go
+++ b/internal/chain/synthetic_token_deposit_test.go
@@ -24,35 +24,24 @@ func TestSynthTokenDeposit_Anon(t *testing.T) {
 	db := new(state.StateDB)
 	require.NoError(t, db.Open("mem", true, true))
 
-	chainId := types.Bytes(gtx.ChainID).AsBytes32()
-	se := &state.StateEntry{}
-	se.ChainId = &chainId
-	se.DB = db
+	st, err := NewStateManager(db, gtx)
+	require.ErrorIs(t, err, state.ErrNotFound)
 
-	_, err = SyntheticTokenDeposit{}.DeliverTx(se, gtx)
+	err = SyntheticTokenDeposit{}.DeliverTx(st, gtx)
 	require.NoError(t, err)
 
 	//try to extract the state to see if we have a valid account
-	anonChain, err := db.GetCurrentEntry(chainId[:])
-	require.NoError(t, err)
-
 	tas := new(protocol.AnonTokenAccount)
-	err = tas.UnmarshalBinary(anonChain.Entry)
-	require.NoError(t, err)
+	require.NoError(t, st.LoadAs(st.SponsorChainId, tas))
 	require.Equal(t, types.String(gtx.SigInfo.URL), tas.ChainUrl, "invalid chain header")
 	require.Equalf(t, types.ChainTypeAnonTokenAccount, tas.Type, "chain state is not an anon account, it is %s", tas.ChainHeader.Type.Name())
 	require.Equal(t, tokenUrl, tas.TokenUrl, "token url of state doesn't match expected")
 	require.Equal(t, uint64(1), tas.TxCount)
 
 	//now query the tx reference
-	refUrl := fmt.Sprintf("%s/%d", gtx.SigInfo.URL, tas.TxCount-1)
-	refChainId := types.GetChainIdFromChainPath(&refUrl)
-	refChainObject, err := db.GetCurrentEntry(refChainId.Bytes())
-	require.NoError(t, err)
-
-	txRef := state.TxReference{}
-	err = txRef.UnmarshalBinary(refChainObject.Entry)
-	require.NoError(t, err)
-	require.Equal(t, types.String(refUrl), txRef.ChainUrl, "chain header expected transaction reference")
+	refUrl := st.SponsorUrl.JoinPath(fmt.Sprint(tas.TxCount - 1))
+	txRef := new(state.TxReference)
+	require.NoError(t, st.LoadUrlAs(refUrl, txRef))
+	require.Equal(t, types.String(refUrl.String()), txRef.ChainUrl, "chain header expected transaction reference")
 	require.Equal(t, gtx.TransactionHash(), txRef.TxId[:], "txid doesn't match")
 }

--- a/internal/chain/token_account_create.go
+++ b/internal/chain/token_account_create.go
@@ -1,7 +1,6 @@
 package chain
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/AccumulateNetwork/accumulated/internal/url"
@@ -16,16 +15,7 @@ type TokenAccountCreate struct{}
 
 func (TokenAccountCreate) Type() types.TxType { return types.TxTypeTokenAccountCreate }
 
-func checkTokenAccountCreate(st *state.StateEntry, tx *transactions.GenTransaction) (accountUrl, tokenUrl *url.URL, err error) {
-	if st.ChainHeader == nil {
-		return nil, nil, fmt.Errorf("sponsor not found")
-	}
-
-	sponsorUrl, err := url.Parse(tx.SigInfo.URL)
-	if err != nil {
-		return nil, nil, fmt.Errorf("invalid sponsor URL: %v", err)
-	}
-
+func checkTokenAccountCreate(st *StateManager, tx *transactions.GenTransaction) (accountUrl, tokenUrl *url.URL, err error) {
 	body := new(api.TokenAccount)
 	err = tx.As(body)
 	if err != nil {
@@ -43,40 +33,31 @@ func checkTokenAccountCreate(st *state.StateEntry, tx *transactions.GenTransacti
 	}
 	// TODO Make sure tokenUrl is a real kind of token
 
-	if !bytes.Equal(accountUrl.IdentityChain(), sponsorUrl.IdentityChain()) {
-		return nil, nil, fmt.Errorf("%q cannot sponsor %q", sponsorUrl.String(), accountUrl.String())
+	if !accountUrl.Identity().Equal(st.SponsorUrl) {
+		return nil, nil, fmt.Errorf("%q cannot sponsor %q", st.SponsorUrl, accountUrl)
 	}
 
 	return accountUrl, tokenUrl, nil
 }
 
-func (TokenAccountCreate) CheckTx(st *state.StateEntry, tx *transactions.GenTransaction) error {
+func (TokenAccountCreate) CheckTx(st *StateManager, tx *transactions.GenTransaction) error {
 	_, _, err := checkTokenAccountCreate(st, tx)
 	return err
 }
 
-func (TokenAccountCreate) DeliverTx(st *state.StateEntry, tx *transactions.GenTransaction) (*DeliverTxResult, error) {
+func (TokenAccountCreate) DeliverTx(st *StateManager, tx *transactions.GenTransaction) error {
 	accountUrl, tokenUrl, err := checkTokenAccountCreate(st, tx)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	scc := new(protocol.SyntheticCreateChain)
 	scc.Cause = types.Bytes(tx.TransactionHash()).AsBytes32()
 	err = scc.Add(state.NewTokenAccount(accountUrl.String(), tokenUrl.String()))
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal synthetic TX: %v", err)
+		return fmt.Errorf("failed to marshal synthetic TX: %v", err)
 	}
 
-	syn := new(transactions.GenTransaction)
-	syn.SigInfo = new(transactions.SignatureInfo)
-	syn.SigInfo.URL = accountUrl.String()
-	syn.Transaction, err = scc.MarshalBinary()
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal synthetic transaction")
-	}
-
-	res := new(DeliverTxResult)
-	res.AddSyntheticTransaction(syn)
-	return res, nil
+	st.Submit(accountUrl, scc)
+	return nil
 }

--- a/internal/chain/token_transaction_test.go
+++ b/internal/chain/token_transaction_test.go
@@ -32,38 +32,25 @@ func TestAnonTokenTransactions(t *testing.T) {
 	anonAcct := new(protocol.AnonTokenAccount)
 	require.NoError(t, anonChain.As(anonAcct))
 
-	se := &state.StateEntry{}
-	se.DB = db
-
 	//now move some tokens around
 	destAddr := anon.GenerateAcmeAddress(destPrivKey[32:])
-	gtx, err := testing2.BuildTestTokenTxGenTx(&destPrivKey, destAddr, 199)
+	gtx, err := testing2.BuildTestTokenTxGenTx(privKey, destAddr, 199)
 
-	chainId := types.Bytes(gtx.ChainID).AsBytes32()
-	se.ChainId = &chainId
-	se.ChainState = anonChain
-	se.ChainHeader = &anonAcct.ChainHeader
-	_, err = TokenTx{}.DeliverTx(se, gtx)
+	st, err := NewStateManager(db, gtx)
+	require.NoError(t, err)
+
+	err = TokenTx{}.DeliverTx(st, gtx)
 	require.NoError(t, err)
 
 	//pull the chains again
-	anonChain, err = db.GetCurrentEntry(chainId[:])
-	require.NoError(t, err)
-
 	tas := new(protocol.AnonTokenAccount)
-	err = tas.UnmarshalBinary(anonChain.Entry)
-	require.NoError(t, err)
+	require.NoError(t, st.LoadAs(st.SponsorChainId, tas))
 	require.Equal(t, tokenUrl, types.String(tas.TokenUrl), "token url of state doesn't match expected")
 	require.Equal(t, uint64(2), tas.TxCount, "expected a token transaction count of 2")
 
-	refUrl := fmt.Sprintf("%s/%d", gtx.SigInfo.URL, tas.TxCount-1)
-	refChainId := types.GetChainIdFromChainPath(&refUrl)
-	refChainObject, err := db.GetCurrentEntry(refChainId.Bytes())
-	require.NoError(t, err)
-
-	txRef := state.TxReference{}
-	err = txRef.UnmarshalBinary(refChainObject.Entry)
-	require.NoError(t, err)
-	require.Equal(t, types.String(refUrl), txRef.ChainUrl, "chain header expected transaction reference")
+	refUrl := st.SponsorUrl.JoinPath(fmt.Sprint(tas.TxCount - 1))
+	txRef := new(state.TxReference)
+	require.NoError(t, st.LoadUrlAs(refUrl, txRef))
+	require.Equal(t, types.String(refUrl.String()), txRef.ChainUrl, "chain header expected transaction reference")
 	require.Equal(t, gtx.TransactionHash(), txRef.TxId[:], "txid doesn't match")
 }

--- a/internal/testing/load.go
+++ b/internal/testing/load.go
@@ -138,7 +138,7 @@ func BuildTestSynthDepositGenTx(origin ed25519.PrivateKey) (types.String, ed2551
 	tokenUrl := types.String(protocol.AcmeUrl().String())
 
 	//create a fake synthetic deposit for faucet.
-	deposit := synthetic.NewTokenTransactionDeposit(txid[:], &adiSponsor, &destAddress)
+	deposit := synthetic.NewTokenTransactionDeposit(txid[:], adiSponsor, destAddress)
 	amtToDeposit := int64(50000)                             //deposit 50k tokens
 	deposit.DepositAmount.SetInt64(amtToDeposit * 100000000) // assume 8 decimal places
 	deposit.TokenUrl = tokenUrl
@@ -168,9 +168,9 @@ func BuildTestSynthDepositGenTx(origin ed25519.PrivateKey) (types.String, ed2551
 	return destAddress, privateKey, gtx, nil
 }
 
-func BuildTestTokenTxGenTx(origin *ed25519.PrivateKey, destAddr string, amount uint64) (*transactions.GenTransaction, error) {
+func BuildTestTokenTxGenTx(sponsor ed25519.PrivateKey, destAddr string, amount uint64) (*transactions.GenTransaction, error) {
 	//use the public key of the bvc to make a sponsor address (this doesn't really matter right now, but need something so Identity of the BVC is good)
-	from := types.String(anon.GenerateAcmeAddress(origin.Public().(ed25519.PublicKey)))
+	from := types.String(anon.GenerateAcmeAddress(sponsor.Public().(ed25519.PublicKey)))
 
 	tokenTx := apitypes.TokenTx{}
 
@@ -191,8 +191,8 @@ func BuildTestTokenTxGenTx(origin *ed25519.PrivateKey, destAddr string, amount u
 
 	ed := new(transactions.ED25519Sig)
 	gtx.SigInfo.Unused2 = 1
-	ed.PublicKey = (*origin)[32:]
-	err = ed.Sign(gtx.SigInfo.Unused2, *origin, gtx.TransactionHash())
+	ed.PublicKey = sponsor[32:]
+	err = ed.Sign(gtx.SigInfo.Unused2, sponsor, gtx.TransactionHash())
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign TX: %v", err)
 	}

--- a/internal/testing/state.go
+++ b/internal/testing/state.go
@@ -24,7 +24,7 @@ func CreateFakeSyntheticDepositTx(sponsor, recipient ed25519.PrivKey) (*transact
 	//create a fake synthetic deposit for faucet.
 	fakeTxid := sha256.Sum256([]byte("fake txid"))
 	// NewTokenTransactionDeposit(txId types.Bytes, from *types.String, to *types.String)
-	deposit := synthetic.NewTokenTransactionDeposit(fakeTxid[:], &sponsorAdi, &recipientAdi)
+	deposit := synthetic.NewTokenTransactionDeposit(fakeTxid[:], sponsorAdi, recipientAdi)
 	amtToDeposit := int64(50000)                           //deposit 50k tokens
 	deposit.DepositAmount.SetInt64(amtToDeposit * TokenMx) // assume 8 decimal places
 	deposit.TokenUrl = types.String(protocol.AcmeUrl().String())
@@ -55,6 +55,7 @@ func CreateFakeSyntheticDepositTx(sponsor, recipient ed25519.PrivKey) (*transact
 
 func CreateAnonTokenAccount(db *state.StateDB, key ed25519.PrivKey, tokens float64) error {
 	url := types.String(anon.GenerateAcmeAddress(key.PubKey().Bytes()))
+	fmt.Println(url)
 	return CreateTokenAccount(db, string(url), protocol.AcmeUrl().String(), tokens, true)
 }
 
@@ -65,7 +66,7 @@ func WriteStates(db *state.StateDB, chains ...state.Chain) error {
 			return err
 		}
 
-		u, err := url.Parse(chain.GetChainUrl())
+		u, err := chain.Header().ParseUrl()
 		if err != nil {
 			return err
 		}

--- a/types/state/Chain.go
+++ b/types/state/Chain.go
@@ -14,8 +14,7 @@ import (
 type Chain interface {
 	encoding.BinaryMarshaler
 	encoding.BinaryUnmarshaler
-	GetType() types.ChainType
-	GetChainUrl() string
+	Header() *ChainHeader
 }
 
 //ChainHeader information for the state object.  Each state object will contain a header
@@ -28,6 +27,8 @@ type ChainHeader struct {
 	// transient
 	url *url.URL
 }
+
+func (h *ChainHeader) Header() *ChainHeader { return h }
 
 //SetHeader sets the data for a chain header
 func (h *ChainHeader) SetHeader(chainUrl types.String, chainType types.ChainType) {

--- a/types/state/Object.go
+++ b/types/state/Object.go
@@ -3,7 +3,6 @@ package state
 import (
 	"bytes"
 	"encoding"
-	"errors"
 	"fmt"
 
 	"github.com/AccumulateNetwork/accumulated/types"
@@ -53,34 +52,4 @@ func (app *Object) UnmarshalBinary(data []byte) (err error) {
 
 func (o *Object) As(entry encoding.BinaryUnmarshaler) error {
 	return entry.UnmarshalBinary(o.Entry)
-}
-
-type StateEntry struct {
-	ChainState  *Object
-	ChainId     *types.Bytes32
-	ChainHeader *ChainHeader
-
-	DB *StateDB
-}
-
-// LoadChainState retrieves the specified chain and unmarshals it, and
-// retrieves its ADI and unmarshals it.
-func (s *StateDB) LoadChainState(chainId []byte) (*StateEntry, error) {
-	chain32 := types.Bytes(chainId).AsBytes32()
-	chainState, chainHeader, err := s.LoadChain(chainId)
-	if errors.Is(err, ErrNotFound) {
-		return &StateEntry{
-			DB:      s,
-			ChainId: &chain32,
-		}, nil
-	} else if err != nil {
-		return nil, err
-	}
-
-	return &StateEntry{
-		DB:          s,
-		ChainId:     &chain32,
-		ChainState:  chainState,
-		ChainHeader: chainHeader,
-	}, nil
 }

--- a/types/synthetic/TokenTransactionDeposit.go
+++ b/types/synthetic/TokenTransactionDeposit.go
@@ -17,7 +17,7 @@ type TokenTransactionDeposit struct {
 	Metadata      *json.RawMessage `json:"meta,omitempty" form:"meta" query:"meta" validate:"required"`
 }
 
-func (tx *TokenTransactionDeposit) SetDeposit(tokenUrl *types.String, amt *big.Int) error {
+func (tx *TokenTransactionDeposit) SetDeposit(tokenUrl types.String, amt *big.Int) error {
 
 	if amt == nil {
 		return fmt.Errorf("no deposito amount specified")
@@ -27,15 +27,15 @@ func (tx *TokenTransactionDeposit) SetDeposit(tokenUrl *types.String, amt *big.I
 		return fmt.Errorf("deposit amount must be greater than 0")
 	}
 
-	tx.TokenUrl = *tokenUrl
+	tx.TokenUrl = tokenUrl
 	tx.DepositAmount.Set(amt)
 
 	return nil
 }
 
-func NewTokenTransactionDeposit(txId types.Bytes, from *types.String, to *types.String) *TokenTransactionDeposit {
+func NewTokenTransactionDeposit(txId types.Bytes, from types.String, to types.String) *TokenTransactionDeposit {
 	tx := TokenTransactionDeposit{}
-	tx.SetHeader(txId, from, to)
+	tx.SetHeader(txId, &from, &to)
 	return &tx
 }
 

--- a/types/synthetic/TokenTransactionDeposit_test.go
+++ b/types/synthetic/TokenTransactionDeposit_test.go
@@ -31,10 +31,10 @@ func TestTokenTransactionDeposit(t *testing.T) {
 	idCoinbase := types.String("fakecoinbaseid/fakecoinbasetoken")
 
 	txid := sha256.Sum256(ledger)
-	dep := NewTokenTransactionDeposit(txid[:], &fromAccount, &toAccount)
+	dep := NewTokenTransactionDeposit(txid[:], fromAccount, toAccount)
 	depAmt := types.Amount{}
 	depAmt.SetInt64(int64(amt))
-	err = dep.SetDeposit(&idCoinbase, depAmt.AsBigInt())
+	err = dep.SetDeposit(idCoinbase, depAmt.AsBigInt())
 
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
- Remove `state.StateEntry`
- Remove `chain.DeliverTxResult`
- Add `chain.StateManager`
  - Loads chains, with a cache
  - Unmarshals loaded chains by type
  - Tracks pending writes
  - Tracks pending synthetic transactions
- Update executor
  - Execute pending writes on success
  - Execute pending synthetic transactions on success