### PR TITLE
Disable init follower

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -44,10 +44,10 @@ jobs:
       - name: Init main
         run: ./accumulated init -w .nodes -n EastXeons -r EastXeons
 
-      - name: Init follower
-        run: |
-          rm -rf .nodes
-          ./accumulated init follower -w .nodes -n EastXeons -l tcp://127.0.2.1:3000
+      # - name: Init follower
+      #   run: |
+      #     rm -rf .nodes
+      #     ./accumulated init follower -w .nodes -n EastXeons -l tcp://127.0.2.1:3000
 
       # - name: Run follower
       #   run: ./accumulated run -w .nodes/Node0 --ci-stop-after 5s


### PR DESCRIPTION
Init follower pulls the genesis block from East Xeons 0 (18.119.26.7). That request has been timing out, so I'm going to disable it.