### PR TITLE
feat: query by txid

### DIFF
--- a/internal/api/jsonrpc_test.go
+++ b/internal/api/jsonrpc_test.go
@@ -102,12 +102,11 @@ func TestLoadOnRemote(t *testing.T) {
 }
 
 func TestJsonRpcAnonToken(t *testing.T) {
-	if os.Getenv("CI") == "true" {
-		t.Skip("This test is flaky in CI")
-	}
-
-	if testing.Short() {
+	switch {
+	case testing.Short():
 		t.Skip("Skipping test in short mode")
+	case os.Getenv("CI") == "true":
+		t.Skip("This test is flaky in CI")
 	}
 
 	//make a client, and also spin up the router grpc
@@ -212,12 +211,13 @@ func TestJsonRpcAnonToken(t *testing.T) {
 }
 
 func TestFaucet(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Tendermint does not close all its open files on shutdown, which causes cleanup to fail")
-	}
-
-	if testing.Short() {
+	switch {
+	case testing.Short():
 		t.Skip("Skipping test in short mode")
+	case runtime.GOOS == "windows":
+		t.Skip("Tendermint does not close all its open files on shutdown, which causes cleanup to fail")
+	case runtime.GOOS == "darwin" && os.Getenv("CI") == "true":
+		t.Skip("This test is flaky in macOS CI")
 	}
 
 	//make a client, and also spin up the router grpc
@@ -324,12 +324,13 @@ func TestFaucet(t *testing.T) {
 }
 
 func TestTransactionHistory(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Tendermint does not close all its open files on shutdown, which causes cleanup to fail")
-	}
-
-	if testing.Short() {
+	switch {
+	case testing.Short():
 		t.Skip("Skipping test in short mode")
+	case runtime.GOOS == "windows":
+		t.Skip("Tendermint does not close all its open files on shutdown, which causes cleanup to fail")
+	case runtime.GOOS == "darwin" && os.Getenv("CI") == "true":
+		t.Skip("This test is flaky in macOS CI")
 	}
 
 	//make a client, and also spin up the router grpc
@@ -426,12 +427,11 @@ func TestMetrics(t *testing.T) {
 }
 
 func TestQueryNotFound(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Fails on windows (Tendermint cleanup issue)")
-	}
-
-	if os.Getenv("CI") == "true" {
-		t.Skip("Flaky in CI")
+	switch {
+	case testing.Short():
+		t.Skip("Skipping test in short mode")
+	case runtime.GOOS == "windows":
+		t.Skip("Tendermint does not close all its open files on shutdown, which causes cleanup to fail")
 	}
 
 	//make a client, and also spin up the router grpc
@@ -512,12 +512,13 @@ func TestDirectory(t *testing.T) {
 }
 
 func TestFaucetReplay(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Tendermint does not close all its open files on shutdown, which causes cleanup to fail")
-	}
-
-	if testing.Short() {
+	switch {
+	case testing.Short():
 		t.Skip("Skipping test in short mode")
+	case runtime.GOOS == "windows":
+		t.Skip("Tendermint does not close all its open files on shutdown, which causes cleanup to fail")
+	case runtime.GOOS == "darwin" && os.Getenv("CI") == "true":
+		t.Skip("This test is flaky in macOS CI")
 	}
 
 	_, kpSponsor, _ := ed25519.GenerateKey(nil)

--- a/internal/url/url.go
+++ b/internal/url/url.go
@@ -133,6 +133,13 @@ func (u *URL) Password() string {
 	return s
 }
 
+// QueryValues parses Query and returns the corresponding values. It silently
+// discards malformed value pairs. To check errors use net/url.ParseQuery.
+func (u *URL) QueryValues() url.Values {
+	v, _ := url.ParseQuery(u.Query)
+	return v
+}
+
 func chain(s string) []byte {
 	s = strings.ToLower(s)
 	h := sha256.Sum256([]byte(s))


### PR DESCRIPTION
Add support to `chain.Executor.Query` for querying transactions by URL with `?txid=...`