### PR TITLE
fix: check for existing ADI

### DIFF
--- a/internal/abci/e2e_test.go
+++ b/internal/abci/e2e_test.go
@@ -341,7 +341,7 @@ func TestCreateSigSpecGroup(t *testing.T) {
 }
 
 func TestAddSigSpec(t *testing.T) {
-	n := createAppWithMemDB(t, crypto.Address{}, "error")
+	n := createAppWithMemDB(t, crypto.Address{}, "info")
 	fooKey, testKey1, testKey2 := generateKey(), generateKey(), generateKey()
 
 	u := n.ParseUrl("foo/ssg1")

--- a/internal/abci/utils_test.go
+++ b/internal/abci/utils_test.go
@@ -46,7 +46,7 @@ func createApp(t testing.TB, db *state.StateDB, addr crypto.Address, logLevel st
 	n.db = db
 
 	zl := logging.NewTestZeroLogger(t, "plain")
-	zl = zl.Hook(logging.ExcludeMessages("AddStateEntry", "WriteStates", "AddTransaction", "AddSynthTx"))
+	zl = zl.Hook(logging.ExcludeMessages("GetIndex", "WriteIndex"))
 	zl = zl.Hook(logging.BodyHook(func(e *zerolog.Event, _ zerolog.Level, body map[string]interface{}) {
 		module, ok := body["module"].(string)
 		if !ok {

--- a/internal/chain/state.go
+++ b/internal/chain/state.go
@@ -256,7 +256,7 @@ func (m *StateManager) commit() error {
 			create[idStr] = scc
 		}
 
-		scc.Chains = append(scc.Chains, data)
+		scc.Chains = append(scc.Chains, protocol.ChainParams{Data: data})
 	}
 
 	return nil

--- a/internal/cmd/gentypes/main.go
+++ b/internal/cmd/gentypes/main.go
@@ -130,7 +130,7 @@ func fieldError(op, name string, args ...string) string {
 func binarySize(w *bytes.Buffer, field *Field, varName string) {
 	var expr string
 	switch field.Type {
-	case "bytes", "string", "chainSet", "uvarint", "duration":
+	case "bool", "bytes", "string", "chainSet", "uvarint", "duration":
 		expr = field.Type + "BinarySize(%s)"
 	case "bigint", "chain":
 		expr = field.Type + "BinarySize(&%s)"
@@ -160,7 +160,7 @@ func binaryMarshalValue(w *bytes.Buffer, field *Field, varName, errName string, 
 	var expr string
 	var canErr bool
 	switch field.Type {
-	case "bytes", "string", "chainSet", "uvarint", "duration":
+	case "bool", "bytes", "string", "chainSet", "uvarint", "duration":
 		expr, canErr = field.Type+"MarshalBinary(%s)", false
 	case "bigint", "chain":
 		expr, canErr = field.Type+"MarshalBinary(&%s)", false
@@ -196,7 +196,7 @@ func binaryUnmarshalValue(w *bytes.Buffer, field *Field, varName, errName string
 	var expr, size, sliceName string
 	var inPlace bool
 	switch field.Type {
-	case "bytes", "string", "chainSet", "uvarint", "duration":
+	case "bool", "bytes", "string", "chainSet", "uvarint", "duration":
 		expr, size, inPlace = field.Type+"UnmarshalBinary(data)", field.Type+"BinarySize(%s)", false
 	case "bigint", "chain":
 		expr, size, inPlace = field.Type+"UnmarshalBinary(data)", field.Type+"BinarySize(&%s)", false

--- a/protocol/transaction.go
+++ b/protocol/transaction.go
@@ -22,14 +22,26 @@ func (scc *SyntheticCreateChain) GetCause() [32]byte {
 	return scc.Cause
 }
 
-func (scc *SyntheticCreateChain) Add(chains ...state.Chain) error {
+func (scc *SyntheticCreateChain) Create(chains ...state.Chain) error {
 	for _, chain := range chains {
 		b, err := chain.MarshalBinary()
 		if err != nil {
 			return err
 		}
 
-		scc.Chains = append(scc.Chains, b)
+		scc.Chains = append(scc.Chains, ChainParams{Data: b})
+	}
+	return nil
+}
+
+func (scc *SyntheticCreateChain) Update(chains ...state.Chain) error {
+	for _, chain := range chains {
+		b, err := chain.MarshalBinary()
+		if err != nil {
+			return err
+		}
+
+		scc.Chains = append(scc.Chains, ChainParams{Data: b, IsUpdate: true})
 	}
 	return nil
 }

--- a/protocol/types.yml
+++ b/protocol/types.yml
@@ -56,15 +56,15 @@ SyntheticCreateChain:
     - name: Chains
       type: slice
       slice:
-        type: bytes
+        type: ChainParams
+        marshal-as: self
 
 ChainParams:
   fields:
-    - name: Url
-      type: string
-      is-url: true
     - name: Data
       type: bytes
+    - name: IsUpdate
+      type: bool
 
 AddCredits:
   kind: tx

--- a/protocol/utils.go
+++ b/protocol/utils.go
@@ -10,6 +10,31 @@ import (
 	"github.com/AccumulateNetwork/accumulated/smt/common"
 )
 
+func boolBinarySize(v bool) int {
+	return 1
+}
+
+func boolMarshalBinary(v bool) []byte {
+	if v {
+		return []byte{1}
+	}
+	return []byte{0}
+}
+
+func boolUnmarshalBinary(b []byte) (bool, error) {
+	if len(b) == 0 {
+		return false, ErrNotEnoughData
+	}
+	switch b[0] {
+	case 0:
+		return false, nil
+	case 1:
+		return true, nil
+	default:
+		return false, fmt.Errorf("%d is not a valid boolean", b[0])
+	}
+}
+
 func uvarintBinarySize(v uint64) int {
 	return len(uvarintMarshalBinary(v))
 }


### PR DESCRIPTION
Updates synthetic chain create so the caller has to specify if a chain is being created or updated, and SCC will fail if the chain does/does not exist (respectively).