### PR TITLE
Ac 474 human readable output for cli

### DIFF
--- a/cmd/cli/cmd/account.go
+++ b/cmd/cli/cmd/account.go
@@ -102,22 +102,23 @@ func PrintAccount() {
 
 func GetAccount(url string) {
 
-	var res interface{}
-	var str []byte
+	var res acmeapi.APIDataResponse
+	//var str []byte
 
 	params := acmeapi.APIRequestURL{}
 	params.URL = types.String(url)
 
 	if err := Client.Request(context.Background(), "token-account", params, &res); err != nil {
-		log.Fatal(err)
+		PrintJsonRpcError(err)
 	}
 
-	str, err := json.Marshal(res)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	fmt.Println(string(str))
+	PrintQueryResponse(&res)
+	//str, err := json.Marshal(res)
+	//if err != nil {
+	//	log.Fatalf("error marshaling result, %v", err)
+	//}
+	//
+	//fmt.Println(string(str))
 
 }
 

--- a/cmd/cli/cmd/adi.go
+++ b/cmd/cli/cmd/adi.go
@@ -136,7 +136,6 @@ func GetADI(url string) {
 	}
 
 	fmt.Println(string(str))
-
 }
 
 func NewADIFromADISigner(actor *url2.URL, args []string) {
@@ -207,16 +206,17 @@ func NewADIFromADISigner(actor *url2.URL, args []string) {
 		log.Fatal(err)
 	}
 
-	var res interface{}
-	var str []byte
+	var res acmeapi.APIDataResponse
 	if err := Client.Request(context.Background(), "adi-create", params, &res); err != nil {
 		log.Fatal(err)
 	}
 
-	str, err = json.Marshal(res)
+	ar := ActionResponse{}
+	err = json.Unmarshal(*res.Data, &ar)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal("error unmarshalling create adi result")
 	}
+	ar.Print()
 
 	//todo: turn around and query the ADI and store the results.
 	err = Db.Update(func(tx *bolt.Tx) error {
@@ -228,7 +228,6 @@ func NewADIFromADISigner(actor *url2.URL, args []string) {
 		}
 		return nil
 	})
-	fmt.Println(string(str))
 
 }
 
@@ -239,20 +238,8 @@ func NewADI(actor string, params []string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	//
-	//if IsLiteAccount(u.String()) == true {
-	//	var book string
-	//	var page string
-	//	if len(params) > 2 {
-	//		book = params[2]
-	//	}
-	//	if len(params) > 3 {
-	//		page = params[3]
-	//	}
-	//	NewADIFromLiteAccount(u, params[0], params[1], book, page)
-	//} else {
+
 	NewADIFromADISigner(u, params[:])
-	//}
 }
 
 func ListADIs() {

--- a/cmd/cli/cmd/adi.go
+++ b/cmd/cli/cmd/adi.go
@@ -81,7 +81,7 @@ func PrintAdiDirectory() {
 	fmt.Println("  accumulate adi directory [url] 		Get directory of URL's associated with an ADI")
 }
 
-func GetAdiDirectory(actor string) *json.RawMessage {
+func GetAdiDirectory(actor string) {
 
 	u, err := url2.Parse(actor)
 	if err != nil {
@@ -89,26 +89,17 @@ func GetAdiDirectory(actor string) *json.RawMessage {
 		log.Fatal(err)
 	}
 
-	var res interface{}
-	var str []byte
+	var res acmeapi.APIDataResponse
 
 	params := acmeapi.APIRequestURL{}
 
 	params.URL = types.String(u.String())
 
 	if err := Client.Request(context.Background(), "get-directory", params, &res); err != nil {
-		log.Fatal(err)
+		PrintJsonRpcError(err)
 	}
 
-	str, err = json.Marshal(res)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	fmt.Println(string(str))
-	ret := json.RawMessage{}
-	ret = str
-	return &ret
+	PrintQueryResponse(&res)
 }
 
 func PrintADI() {
@@ -120,22 +111,22 @@ func PrintADI() {
 
 func GetADI(url string) {
 
-	var res interface{}
-	var str []byte
+	var res acmeapi.APIDataResponse
 
 	params := acmeapi.APIRequestURL{}
 	params.URL = types.String(url)
 
 	if err := Client.Request(context.Background(), "adi", params, &res); err != nil {
-		log.Fatal(err)
+		PrintJsonRpcError(err)
 	}
 
-	str, err := json.Marshal(res)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	fmt.Println(string(str))
+	PrintQueryResponse(&res)
+	//str, err := json.Marshal(res)
+	//if err != nil {
+	//	log.Fatal(err)
+	//}
+	//
+	//fmt.Println(string(str))
 }
 
 func NewADIFromADISigner(actor *url2.URL, args []string) {
@@ -208,7 +199,7 @@ func NewADIFromADISigner(actor *url2.URL, args []string) {
 
 	var res acmeapi.APIDataResponse
 	if err := Client.Request(context.Background(), "adi-create", params, &res); err != nil {
-		log.Fatal(err)
+		PrintJsonRpcError(err)
 	}
 
 	ar := ActionResponse{}

--- a/cmd/cli/cmd/book.go
+++ b/cmd/cli/cmd/book.go
@@ -79,7 +79,6 @@ func GetAndPrintKeyBook(url string) {
 		log.Fatal(err)
 	}
 	PrintQueryResponse(&res)
-	//fmt.Println(string(str))
 }
 
 func GetKeyBook(url string) ([]byte, *protocol.SigSpecGroup, error) {

--- a/cmd/cli/cmd/book.go
+++ b/cmd/cli/cmd/book.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/AccumulateNetwork/accumulated/protocol"
+	acmeapi "github.com/AccumulateNetwork/accumulated/types/api"
 	"log"
 	"time"
 
@@ -144,18 +145,17 @@ func CreateKeyBook(book string, args []string) {
 		log.Fatal(err)
 	}
 
-	var res interface{}
-	var str []byte
-	if err := Client.Request(context.Background(), "create-sig-spec-group", params, &res); err != nil {
+	var res acmeapi.APIDataResponse
+	if err := Client.Request(context.Background(), "key-book-create", params, &res); err != nil {
 		log.Fatal(err)
 	}
 
-	str, err = json.Marshal(res)
+	ar := ActionResponse{}
+	err = json.Unmarshal(*res.Data, &ar)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal("error unmarshalling create key book result")
 	}
-
-	fmt.Println(string(str))
+	ar.Print()
 
 }
 

--- a/cmd/cli/cmd/book.go
+++ b/cmd/cli/cmd/book.go
@@ -151,7 +151,7 @@ func CreateKeyBook(book string, args []string) {
 	}
 
 	var res acmeapi.APIDataResponse
-	if err := Client.Request(context.Background(), "key-book-create", params, &res); err != nil {
+	if err := Client.Request(context.Background(), "create-sig-spec-group", params, &res); err != nil {
 		PrintJsonRpcError(err)
 	}
 

--- a/cmd/cli/cmd/book.go
+++ b/cmd/cli/cmd/book.go
@@ -73,7 +73,13 @@ func GetAndPrintKeyBook(url string) {
 		log.Fatal(fmt.Errorf("error retrieving key book for %s", url))
 	}
 
-	fmt.Println(string(str))
+	res := acmeapi.APIDataResponse{}
+	err = json.Unmarshal([]byte(str), &res)
+	if err != nil {
+		log.Fatal(err)
+	}
+	PrintQueryResponse(&res)
+	//fmt.Println(string(str))
 }
 
 func GetKeyBook(url string) ([]byte, *protocol.SigSpecGroup, error) {
@@ -147,7 +153,7 @@ func CreateKeyBook(book string, args []string) {
 
 	var res acmeapi.APIDataResponse
 	if err := Client.Request(context.Background(), "key-book-create", params, &res); err != nil {
-		log.Fatal(err)
+		PrintJsonRpcError(err)
 	}
 
 	ar := ActionResponse{}

--- a/cmd/cli/cmd/credits.go
+++ b/cmd/cli/cmd/credits.go
@@ -97,7 +97,14 @@ func AddCredits(actor string, args []string) {
 	ar := ActionResponse{}
 	err = json.Unmarshal(*res.Data, &ar)
 	if err != nil {
-		log.Fatal("error unmarshalling create adi result")
+		resData, err := json.Marshal(&res)
+		var out string
+		if err != nil {
+			out = fmt.Sprintf("%v", err)
+		} else {
+			out = string(resData)
+		}
+		log.Fatalf("error unmarshalling add credits result %s", out)
 	}
 	ar.Print()
 }

--- a/cmd/cli/cmd/credits.go
+++ b/cmd/cli/cmd/credits.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	acmeapi "github.com/AccumulateNetwork/accumulated/types/api"
 	"log"
 	"strconv"
 	"time"
@@ -67,8 +68,7 @@ func AddCredits(actor string, args []string) {
 		PrintCredits()
 		log.Fatal(fmt.Errorf("amount must be an integer %v", err))
 	}
-	var res interface{}
-	var str []byte
+	var res acmeapi.APIDataResponse
 
 	credits := protocol.AddCredits{}
 	credits.Recipient = u2.String()
@@ -94,10 +94,10 @@ func AddCredits(actor string, args []string) {
 		log.Fatal(err)
 	}
 
-	str, err = json.Marshal(res)
+	ar := ActionResponse{}
+	err = json.Unmarshal(*res.Data, &ar)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal("error unmarshalling create adi result")
 	}
-
-	fmt.Println(string(str))
+	ar.Print()
 }

--- a/cmd/cli/cmd/faucet.go
+++ b/cmd/cli/cmd/faucet.go
@@ -35,21 +35,17 @@ func PrintFaucet() {
 
 func Faucet(url string) {
 
-	var res interface{}
-	var str []byte
-
+	var res acmeapi.APIDataResponse
 	params := acmeapi.APIRequestURL{}
 	params.URL = types.String(url)
 
 	if err := Client.Request(context.Background(), "faucet", params, &res); err != nil {
 		log.Fatal(err)
 	}
-
-	str, err := json.Marshal(res)
+	ar := ActionResponse{}
+	err := json.Unmarshal(*res.Data, &ar)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal("error unmarshalling create adi result")
 	}
-
-	fmt.Println(string(str))
-
+	ar.Print()
 }

--- a/cmd/cli/cmd/get.go
+++ b/cmd/cli/cmd/get.go
@@ -61,7 +61,7 @@ func GetByChainId(chainId []byte) (*acmeapi.APIDataResponse, error) {
 
 	fmt.Println(string(str1))
 
-	if err := Client.Request(context.Background(), "get", params, &res); err != nil {
+	if err := Client.Request(context.Background(), "chain", params, &res); err != nil {
 		log.Fatal(err)
 	}
 

--- a/cmd/cli/cmd/get.go
+++ b/cmd/cli/cmd/get.go
@@ -26,7 +26,8 @@ var getCmd = &cobra.Command{
 			}
 		default:
 			if len(args) > 0 {
-				Get(args[0])
+				str := Get(args[0])
+				fmt.Println(string(str))
 			} else {
 				fmt.Println("Usage:")
 				PrintGet()
@@ -70,19 +71,10 @@ func GetByChainId(chainId []byte) (*acmeapi.APIDataResponse, error) {
 }
 
 func Get(url string) string {
-
 	var res interface{}
-	var str []byte
 
 	params := acmeapi.APIRequestURL{}
 	params.URL = types.String(url)
-
-	str1, err1 := json.Marshal(&params)
-	if err1 != nil {
-		log.Fatal(err1)
-	}
-
-	fmt.Println(string(str1))
 
 	if err := Client.Request(context.Background(), "get", params, &res); err != nil {
 		log.Fatal(err)
@@ -93,6 +85,5 @@ func Get(url string) string {
 		log.Fatal(err)
 	}
 
-	fmt.Println(string(str))
 	return string(str)
 }

--- a/cmd/cli/cmd/page.go
+++ b/cmd/cli/cmd/page.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	url2 "github.com/AccumulateNetwork/accumulated/internal/url"
+	acmeapi "github.com/AccumulateNetwork/accumulated/types/api"
 	"github.com/spf13/cobra"
 	"log"
 	"time"
@@ -270,16 +271,15 @@ func KeyPageUpdate(actorUrl string, op protocol.KeyPageOperation, args []string)
 		log.Fatal(err)
 	}
 
-	var res interface{}
-	var str []byte
+	var res acmeapi.APIDataResponse
 	if err := Client.Request(context.Background(), "update-key-page", params, &res); err != nil {
 		log.Fatal(err)
 	}
 
-	str, err = json.Marshal(res)
+	ar := ActionResponse{}
+	err = json.Unmarshal(*res.Data, &ar)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal("error unmarshalling create adi result")
 	}
-
-	fmt.Println(string(str))
+	ar.Print()
 }

--- a/cmd/cli/cmd/page.go
+++ b/cmd/cli/cmd/page.go
@@ -84,7 +84,12 @@ func GetAndPrintKeyPage(url string) {
 		log.Fatal(fmt.Errorf("error retrieving key book for %s", url))
 	}
 
-	fmt.Println(string(str))
+	res := acmeapi.APIDataResponse{}
+	err = json.Unmarshal([]byte(str), &res)
+	if err != nil {
+		log.Fatal(err)
+	}
+	PrintQueryResponse(&res)
 }
 
 func GetKeyPage(url string) ([]byte, *protocol.SigSpecGroup, error) {

--- a/cmd/cli/cmd/root.go
+++ b/cmd/cli/cmd/root.go
@@ -16,8 +16,9 @@ import (
 )
 
 var (
-	Client = client.NewAPIClient()
-	Db     = initDB() //initManagedDB()
+	Client         = client.NewAPIClient()
+	Db             = initDB() //initManagedDB()
+	WantJsonOutput = false
 )
 
 var currentUser = func() *user.User {
@@ -47,6 +48,7 @@ var rootCmd = func() *cobra.Command {
 	flags.StringVarP(&Client.Server, "server", "s", defaultServer, "Accumulated server")
 	flags.DurationVarP(&Client.Timeout, "timeout", "t", 5*time.Second, "Timeout for all API requests (i.e. 10s, 1m)")
 	flags.BoolVarP(&Client.DebugRequest, "debug", "d", false, "Print accumulated API calls")
+	flags.BoolVarP(&WantJsonOutput, "json", "j", false, "print outputs as json")
 
 	return cmd
 

--- a/cmd/cli/cmd/tx.go
+++ b/cmd/cli/cmd/tx.go
@@ -106,7 +106,6 @@ func GetTX(hash string) {
 	}
 
 	fmt.Println(string(str))
-
 }
 
 func GetTXHistory(accountUrl string, s string, e string) {
@@ -154,8 +153,7 @@ func GetTXHistory(accountUrl string, s string, e string) {
 
 func CreateTX(sender string, args []string) {
 	//sender string, receiver string, amount string
-	var res interface{}
-	var str []byte
+	var res acmeapi.APIDataResponse
 	var err error
 	u, err := url.Parse(sender)
 	if err != nil {
@@ -204,15 +202,10 @@ func CreateTX(sender string, args []string) {
 		log.Fatal(err)
 	}
 
-	str, err = json.Marshal(res)
+	ar := ActionResponse{}
+	err = json.Unmarshal(*res.Data, &ar)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal("error unmarshalling create adi result")
 	}
-
-	fmt.Println(string(str))
-
-	if err != nil {
-		log.Fatal(err)
-	}
-
+	ar.Print()
 }

--- a/cmd/cli/cmd/tx.go
+++ b/cmd/cli/cmd/tx.go
@@ -97,7 +97,7 @@ func GetTX(hash string) {
 	}
 
 	if err := Client.Request(context.Background(), "token-tx", jsondata, &res); err != nil {
-		log.Fatal(err)
+		PrintJsonRpcError(err)
 	}
 
 	str, err = json.Marshal(res)
@@ -139,7 +139,7 @@ func GetTXHistory(accountUrl string, s string, e string) {
 	}
 
 	if err := Client.Request(context.Background(), "token-account-history", jsondata, &res); err != nil {
-		log.Fatal(err)
+		PrintJsonRpcError(err)
 	}
 
 	str, err = json.Marshal(res)
@@ -179,8 +179,9 @@ func CreateTX(sender string, args []string) {
 
 	to := []*acmeapi.TokenTxOutput{}
 	r := &acmeapi.TokenTxOutput{}
-	amt, err := strconv.ParseUint(amount, 10, 64)
-	r.Amount = uint64(amt)
+
+	amt, err := strconv.ParseFloat(amount, 64)
+	r.Amount = uint64(amt * 1e8)
 	r.URL.String = types.String(u2.String())
 	to = append(to, r)
 	tokentx.To = to

--- a/cmd/cli/cmd/util.go
+++ b/cmd/cli/cmd/util.go
@@ -226,3 +226,37 @@ func dispatchRequest(action string, payload interface{}, actor *url2.URL, si *tr
 
 	return res, nil
 }
+
+type ActionResponse struct {
+	Txid      types.Bytes32 `json:"txid"`
+	Hash      types.Bytes32 `json:"hash"`
+	Log       types.String  `json:"log"`
+	Code      int64         `json:"code"`
+	Codespace types.String  `json:"codespace"`
+	Error     types.String  `json:"error"`
+}
+
+func (a *ActionResponse) Print() {
+	if WantJsonOutput {
+		dump, err := json.Marshal(a)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println(string(dump))
+	} else {
+		fmt.Printf("Transaction Identifier\t:\t%x\n", a.Txid)
+		fmt.Printf("Tendermint Reference\t:\t%x\n", a.Hash)
+		if a.Code != 0 {
+			fmt.Printf("Error code\t:\t%d\n", a.Code)
+		}
+		if a.Error != "" {
+			fmt.Printf("Error\t:\t%s\n", a.Error)
+		}
+		if a.Log != "" {
+			fmt.Printf("Log\t:\t%s\n", a.Log)
+		}
+		if a.Codespace != "" {
+			fmt.Printf("Codespace\t:\t%s\n", a.Codespace)
+		}
+	}
+}

--- a/cmd/cli/cmd/util.go
+++ b/cmd/cli/cmd/util.go
@@ -442,7 +442,7 @@ func PrintQueryResponse(res *acmeapi.APIDataResponse) {
 				log.Fatal(err)
 			}
 			var out string
-			out += fmt.Sprintf("\n\tHeight\t:\tKey Page Url\n")
+			out += fmt.Sprintf("\n\tHeight\t\tKey Page Url\n")
 			for i, v := range ssg.SigSpecs {
 				//enable this code when testnet updated to a version > 0.2.1.
 				//data, err := GetByChainId(v[:])


### PR DESCRIPTION
- added human readable output for book / page /adi / lite account create / update / query, including tx create.
- changed book and page create to use older json-rpc command to be compatible with deployed testnet.
- will humanize tx queries in later task
- will add unit tests in later task